### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# deepdiff v 0.5.7
+# deepdiff v 0.5.8
 
 ![Doc](https://readthedocs.org/projects/deepdiff/badge/?version=latest)
 
@@ -208,6 +208,7 @@ root[4]['b']:
 
 ##Changelog
 
+- v0-5-8: Adding ignore order for unhashables support
 - v0-5-7: Adding ignore order support
 - v0-5-6: Adding slots support
 - v0-5-5: Adding loop detection

--- a/README.md
+++ b/README.md
@@ -201,6 +201,18 @@ root[4]['b']:
 {'attribute_added': ['root.c'], 'values_changed': ['root.b: 1 ===> 2']}
 ```
 
+### Ignoring order:
+
+**Note: If your objects include iterable containing any unhashable item, ignoring the order can be expensive.**
+
+```python
+>>> t1 = [{"a": 2}, {"b": [3, 4, {1: 1}]}]
+>>> t2 = [{"b": [3, 4, {1: 1}]}, {"a": 2}]
+ddiff = DeepDiff(t1, t2, ignore_order=True)
+>>>
+>>> print(DeepDiff(t1, t2))
+{}
+```
 
 ##Documentation
 
@@ -208,7 +220,7 @@ root[4]['b']:
 
 ##Changelog
 
-- v0-5-8: Adding ignore order for unhashables support
+- v0-5-8: Adding ignore order of unhashables support
 - v0-5-7: Adding ignore order support
 - v0-5-6: Adding slots support
 - v0-5-5: Adding loop detection

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ root[4]['b']:
 
 ##Changelog
 
+v0-5-6: Adding slots support
 v0-5-5: Adding loop detection
 
 ##Author

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# deepdiff v 0.5.8
+# deepdiff v 0.5.9
 
 ![Doc](https://readthedocs.org/projects/deepdiff/badge/?version=latest)
 
@@ -220,6 +220,7 @@ ddiff = DeepDiff(t1, t2, ignore_order=True)
 
 ##Changelog
 
+- v0-5-9: Adding decimal support
 - v0-5-8: Adding ignore order of unhashables support
 - v0-5-7: Adding ignore order support
 - v0-5-6: Adding slots support

--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ root[4]['b']:
 
 ##Changelog
 
-v0-5-6: Adding slots support
-v0-5-5: Adding loop detection
+- v0-5-6: Adding slots support
+- v0-5-5: Adding loop detection
 
 ##Author
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# deepdiff v 0.5.6
+# deepdiff v 0.5.7
 
 ![Doc](https://readthedocs.org/projects/deepdiff/badge/?version=latest)
 
@@ -208,6 +208,7 @@ root[4]['b']:
 
 ##Changelog
 
+- v0-5-7: Adding ignore order support
 - v0-5-6: Adding slots support
 - v0-5-5: Adding loop detection
 

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-**DeepDiff v 0.5.6**
+**DeepDiff v 0.5.7**
 
 Deep Difference of dictionaries, iterables, strings and almost any other object. It will recursively look for all the changes.
 
@@ -158,6 +158,7 @@ Object attribute added:
 
 **Changelog**
 
+v0-5-7: Adding ignore order support
 v0-5-6: Adding slots support
 v0-5-5: Adding loop detection
 

--- a/README.txt
+++ b/README.txt
@@ -156,8 +156,18 @@ Object attribute added:
     >>> print(DeepDiff(t1, t2))
     {'attribute_added': ['root.c'], 'values_changed': ['root.b: 1 ===> 2']}
 
+Ignoring order:
+    >>> t1 = [{"a": 2}, {"b": [3, 4, {1: 1}]}]
+    >>> t2 = [{"b": [3, 4, {1: 1}]}, {"a": 2}]
+    ddiff = DeepDiff(t1, t2, ignore_order=True)
+    >>>
+    >>> print(DeepDiff(t1, t2))
+    {}
+
+
 **Changelog**
 
+v0-5-8: Adding ignore order of unhashables support
 v0-5-7: Adding ignore order support
 v0-5-6: Adding slots support
 v0-5-5: Adding loop detection

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-**DeepDiff v 0.5.8**
+**DeepDiff v 0.5.9**
 
 Deep Difference of dictionaries, iterables, strings and almost any other object. It will recursively look for all the changes.
 
@@ -167,6 +167,7 @@ Ignoring order:
 
 **Changelog**
 
+v0-5-9: Adding decimal support
 v0-5-8: Adding ignore order of unhashables support
 v0-5-7: Adding ignore order support
 v0-5-6: Adding slots support

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-**DeepDiff v 0.5.7**
+**DeepDiff v 0.5.8**
 
 Deep Difference of dictionaries, iterables, strings and almost any other object. It will recursively look for all the changes.
 

--- a/deepdiff/deepdiff.py
+++ b/deepdiff/deepdiff.py
@@ -225,16 +225,6 @@ class DeepDiff(dict):
         '''
         return str(type(obj)).replace('class', 'type')
 
-    def __freeze(self, obj):
-        '''
-        Recursively freezes the object. This is necessary when order should be ignored while dealing with unhashable items
-        '''
-        if isinstance(obj, dict):
-            return frozenset((key, self.__freeze(value)) for key, value in getattr(obj, items)())
-        elif isinstance(obj, (list, tuple)):
-            return set(self.__freeze(value) for value in obj)
-        return obj
-
     def __diff_obj(self, t1, t2, parent, parents_ids=frozenset({})):
         ''' difference of 2 objects '''
 

--- a/deepdiff/deepdiff.py
+++ b/deepdiff/deepdiff.py
@@ -43,7 +43,9 @@ class DeepDiff(dict):
     t2 : dictionary, list, string or almost any python object that has __dict__ or __slots__
         The second item is to be compared to the first one
 
-    ignore_order : Boolean, defalt=False igonres orders and duplicates for iterables. Note that if you have iterables contatining any unhashable, ignoring order is very expensive.
+    ignore_order : Boolean, defalt=False ignores orders for iterables. Note that if you have iterables contatining any unhashable, ignoring order can be expensive.
+        Ignoring order for an iterable containing any unhashable will include duplicates if there are any in the iterable.
+        Ignoring order for an iterable containing only hashables, will not include duplicates in the iterable.
 
     **Returns**
 

--- a/deepdiff/deepdiff.py
+++ b/deepdiff/deepdiff.py
@@ -119,8 +119,8 @@ class DeepDiff(dict):
         >>>
         >>> print (ddiff['values_changed'][0])
         root[4]['b']:
-        --- 
-        +++ 
+        ---
+        +++
         @@ -1,5 +1,4 @@
         -world!
         -Goodbye!
@@ -217,6 +217,15 @@ class DeepDiff(dict):
 
         for k in empty_keys:
             del self[k]
+
+    @staticmethod
+    def __getvalue(obj):
+        '''
+        if obj is Unicode str, it maybe throw UnicodeDecodeError when *print* the value
+        '''
+        if isinstance(obj, str):
+            return obj.decode('ascii', 'replace')
+        return obj
 
     @staticmethod
     def __gettype(obj):
@@ -344,7 +353,7 @@ class DeepDiff(dict):
                 diff = '\n'.join(diff)
                 self["values_changed"].append("%s:\n%s" % (parent, diff))
         elif t1 != t2:
-            self["values_changed"].append("%s: '%s' ===> '%s'" % (parent, t1, t2))
+            self["values_changed"].append("%s: '%s' ===> '%s'" % (parent, self.__getvalue(t1), self.__getvalue(t2)))
 
     def __diff_tuple(self, t1, t2, parent, parents_ids):
         # Checking to see if it has _fields. Which probably means it is a named tuple.
@@ -365,7 +374,7 @@ class DeepDiff(dict):
 
         if type(t1) != type(t2):
             self["type_changes"].append(
-                "%s: %s=%s ===> %s=%s" % (parent, t1, self.__gettype(t1), t2, self.__gettype(t2)))
+                "%s: %s=%s ===> %s=%s" % (parent, self.__getvalue(t1), self.__gettype(t1), self.__getvalue(t2), self.__gettype(t2)))
 
         elif isinstance(t1, (basestring, bytes)):
             self.__diff_str(t1, t2, parent)

--- a/deepdiff/deepdiff.py
+++ b/deepdiff/deepdiff.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import difflib
 import datetime
 import json
+from decimal import Decimal
 from sys import version
 
 py3 = version[0] == '3'
@@ -13,11 +14,11 @@ py3 = version[0] == '3'
 if py3:
     from builtins import int
     basestring = str
-    numbers = (int, float, complex, datetime.datetime)
+    numbers = (int, float, complex, datetime.datetime, Decimal)
     from itertools import zip_longest
     items = 'items'
 else:
-    numbers = (int, float, long, complex, datetime.datetime)
+    numbers = (int, float, long, complex, datetime.datetime, Decimal)
     from itertools import izip_longest as zip_longest
     items = 'iteritems'
 
@@ -31,7 +32,7 @@ class ListItemRemovedOrAdded(object):
 class DeepDiff(dict):
 
     r"""
-    **DeepDiff v 0.5.8**
+    **DeepDiff v 0.5.9**
 
     Deep Difference of dictionaries, iterables, strings and almost any other object. It will recursively look for all the changes.
 
@@ -391,8 +392,8 @@ class DeepDiff(dict):
                 except TypeError:
                     try:
                         # This is very expensive but we need to calculate the hash based on the serialized object
-                        t1.sort(key=lambda x: hash(json.dumps(x)))
-                        t2.sort(key=lambda x: hash(json.dumps(x)))
+                        t1.sort(key=lambda x: hash(json.dumps(x, default=json_default)))
+                        t2.sort(key=lambda x: hash(json.dumps(x, default=json_default)))
                     except:
                         print ("Warning: Can not ignore order for an item in %s" % parent)
                     self.__diff_iterable(t1, t2, parent, parents_ids)
@@ -415,6 +416,13 @@ class DeepDiff(dict):
         DeepDiff(t1,t2) == DeepDiff(t1, t2).changes
         '''
         return self
+
+
+def json_default(obj):
+    if isinstance(obj, Decimal):
+        return float(obj)
+    else:
+        raise TypeError
 
 if __name__ == "__main__":
     import doctest

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ Install from PyPi::
 
 
 **************
-DeepDiff 0.5.7
+DeepDiff 0.5.8
 **************
 
 .. toctree::
@@ -42,6 +42,7 @@ Indices and tables
 Changelog
 =========
 
+- v0-5-8: Adding ignore order for unhashables support
 - v0-5-7: Adding ignore order support
 - v0-5-6: Adding slots support
 - v0-5-5: Adding loop detection

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,8 @@ Indices and tables
 Changelog
 =========
 
+- v0-5-7: Adding ignore order support
+- v0-5-6: Adding slots support
 - v0-5-5: Adding loop detection
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ Install from PyPi::
 
 
 **************
-DeepDiff 0.5.8
+DeepDiff 0.5.9
 **************
 
 .. toctree::
@@ -42,6 +42,7 @@ Indices and tables
 Changelog
 =========
 
+- v0-5-9: Adding decimal support
 - v0-5-8: Adding ignore order for unhashables support
 - v0-5-7: Adding ignore order support
 - v0-5-6: Adding slots support

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ Install from PyPi::
 
 
 **************
-DeepDiff 0.5.6
+DeepDiff 0.5.7
 **************
 
 .. toctree::

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except:
     long_description = "Deep Difference of dictionaries, iterables, strings and other objects. It will recursively look for all the changes."
 
 setup(name='deepdiff',
-      version='0.5.7',
+      version='0.5.8',
       description='Deep Difference of dictionaries, iterables, strings and other objects. It will recursively look for all the changes.',
       url='https://github.com/erasmose/deepdiff',
       download_url='https://github.com/erasmose/deepdiff/tarball/master',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except:
     long_description = "Deep Difference of dictionaries, iterables, strings and other objects. It will recursively look for all the changes."
 
 setup(name='deepdiff',
-      version='0.5.8',
+      version='0.5.9',
       description='Deep Difference of dictionaries, iterables, strings and other objects. It will recursively look for all the changes.',
       url='https://github.com/erasmose/deepdiff',
       download_url='https://github.com/erasmose/deepdiff/tarball/master',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except:
     long_description = "Deep Difference of dictionaries, iterables, strings and other objects. It will recursively look for all the changes."
 
 setup(name='deepdiff',
-      version='0.5.6',
+      version='0.5.7',
       description='Deep Difference of dictionaries, iterables, strings and other objects. It will recursively look for all the changes.',
       url='https://github.com/erasmose/deepdiff',
       download_url='https://github.com/erasmose/deepdiff/tarball/master',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -100,6 +100,12 @@ class DeepDiffTestCase(unittest.TestCase):
                          "root[4]['b'][1]: 2 ===> 3", "root[4]['b'][2]: 3 ===> 2"],
                          'iterable_item_added': ["root[4]['b']: [3]"]})
 
+    def test_list_difference_ignore_order(self):
+        t1 = {1: 1, 4: {"a": "hello", "b": [1, 2, 3]}}
+        t2 = {1: 1, 4: {"a": "hello", "b": [1, 3, 2, 3]}}
+        ddiff = DeepDiff(t1, t2, ignore_order=True)
+        self.assertEqual(ddiff, {})
+
     def test_list_that_contains_dictionary(self):
         t1 = {1: 1, 2: 2, 3: 3, 4: {"a": "hello", "b": [1, 2, {1: 1, 2: 2}]}}
         t2 = {1: 1, 2: 2, 3: 3, 4: {"a": "hello", "b": [1, 2, {1: 3}]}}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -106,6 +106,12 @@ class DeepDiffTestCase(unittest.TestCase):
         ddiff = DeepDiff(t1, t2, ignore_order=True)
         self.assertEqual(ddiff, {})
 
+    def test_list_of_unhashable_difference_ignore_order(self):
+        t1 = [{"a": 2}, {"b": [3, 4, {1: 1}]}]
+        t2 = [{"b": [3, 4, {1: 1}]}, {"a": 2}]
+        ddiff = DeepDiff(t1, t2, ignore_order=True)
+        self.assertEqual(ddiff, {})
+
     def test_list_that_contains_dictionary(self):
         t1 = {1: 1, 2: 2, 3: 3, 4: {"a": "hello", "b": [1, 2, {1: 1, 2: 2}]}}
         t2 = {1: 1, 2: 2, 3: 3, 4: {"a": "hello", "b": [1, 2, {1: 3}]}}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -7,6 +7,7 @@ python -m unittest discover
 """
 
 import unittest
+from decimal import Decimal
 
 from deepdiff import DeepDiff
 
@@ -234,3 +235,18 @@ class DeepDiffTestCase(unittest.TestCase):
         ddiff = DeepDiff(t1, t2)
         result = {'values_changed': ['root.a: 1 ===> 2']}
         self.assertEqual(ddiff, result)
+
+    def test_decimal(self):
+        t1 = {1: Decimal('10.1')}
+        t2 = {1: Decimal('2.2')}
+        ddiff = DeepDiff(t1, t2)
+        result = {'values_changed': ['root[1]: 10.1 ===> 2.2']}
+        self.assertEqual(ddiff, result)
+
+    def test_decimal_ignore_order(self):
+        t1 = [{1: Decimal('10.1')}, {2: Decimal('10.2')}]
+        t2 = [{2: Decimal('10.2')}, {1: Decimal('10.1')}]
+        ddiff = DeepDiff(t1, t2, ignore_order=True)
+        result = {}
+        self.assertEqual(ddiff, result)
+


### PR DESCRIPTION
Hi,

When I use DeepDiff, it throws UnicodeDecodeError. I pull this request to solve that. Verified in my local space.

This is my first pull request in github, please correct me if I did something wrong. Thanks.

This is the Trace:
```
   ... Above is my code
    ddiff = DeepDiff(noad_original[i], pack_data[pack_index])
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 214, in __init__
    self.__diff(t1, t2, parents_ids=frozenset({id(t1)}))
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 378, in __diff
    self.__diff_dict(t1, t2, parent, parents_ids)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 278, in __diff_dict
    self.__diff_common_children(t1, t2, t_keys_intersect, print_as_attribute, parents_ids, parent, parent_text)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 301, in __diff_common_children
    self.__diff(t1_child, t2_child, parent=parent_text % (parent, item_key_str), parents_ids=parents_added)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 403, in __diff
    self.__diff_iterable(t1, t2, parent, parents_ids)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 328, in __diff_iterable
    self.__diff(x, y, "%s[%s]" % (parent, i), parents_ids)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 378, in __diff
    self.__diff_dict(t1, t2, parent, parents_ids)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 278, in __diff_dict
    self.__diff_common_children(t1, t2, t_keys_intersect, print_as_attribute, parents_ids, parent, parent_text)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 301, in __diff_common_children
    self.__diff(t1_child, t2_child, parent=parent_text % (parent, item_key_str), parents_ids=parents_added)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 368, in __diff
    "%s: %s=%s ===> %s=%s" % (parent, t1, self.__gettype(t1), t2, self.__gettype(t2)))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe9 in position 33: ordinal not in range(128)
```