### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/deepdiff/deepdiff.py
+++ b/deepdiff/deepdiff.py
@@ -221,10 +221,15 @@ class DeepDiff(dict):
     @staticmethod
     def __getvalue(obj):
         '''
-        if obj is Unicode str, it maybe throw UnicodeDecodeError when *print* the value
+        In python2, if str is not unicode but contains unicode chars, it maybe throw UnicodeDecodeError when *print* the value
+        In python3, as every str is unicode, there is no problem.
         '''
         if isinstance(obj, str):
-            return obj.decode('ascii', 'replace')
+            try:
+                # Python3 will throw exception as str has no decode attr
+                return obj.decode('ascii', 'replace')
+            except AttributeError:
+                return obj
         return obj
 
     @staticmethod
@@ -353,7 +358,7 @@ class DeepDiff(dict):
                 diff = '\n'.join(diff)
                 self["values_changed"].append("%s:\n%s" % (parent, diff))
         elif t1 != t2:
-            self["values_changed"].append("%s: '%s' ===> '%s'" % (parent, self.__getvalue(t1), self.__getvalue(t2)))
+            self["values_changed"].append("%s: '%s' ===> '%s'" % (parent, t1, t2))
 
     def __diff_tuple(self, t1, t2, parent, parents_ids):
         # Checking to see if it has _fields. Which probably means it is a named tuple.

--- a/deepdiff/deepdiff.py
+++ b/deepdiff/deepdiff.py
@@ -119,8 +119,8 @@ class DeepDiff(dict):
         >>>
         >>> print (ddiff['values_changed'][0])
         root[4]['b']:
-        --- 
-        +++ 
+        ---
+        +++
         @@ -1,5 +1,4 @@
         -world!
         -Goodbye!
@@ -217,6 +217,15 @@ class DeepDiff(dict):
 
         for k in empty_keys:
             del self[k]
+
+    @staticmethod
+    def __getvalue(obj):
+        '''
+        if obj is Unicode str, it maybe throw UnicodeDecodeError when *print* the value
+        '''
+        if isinstance(obj, str):
+            return obj.decode('ascii', 'replace')
+        return obj
 
     @staticmethod
     def __gettype(obj):
@@ -344,7 +353,7 @@ class DeepDiff(dict):
                 diff = '\n'.join(diff)
                 self["values_changed"].append("%s:\n%s" % (parent, diff))
         elif t1 != t2:
-            self["values_changed"].append("%s: '%s' ===> '%s'" % (parent, t1, t2))
+            self["values_changed"].append("%s: '%s' ===> '%s'" % (parent, self.__getvalue(t1), self.__getvalue(t2)))
 
     def __diff_tuple(self, t1, t2, parent, parents_ids):
         # Checking to see if it has _fields. Which probably means it is a named tuple.
@@ -365,7 +374,7 @@ class DeepDiff(dict):
 
         if type(t1) != type(t2):
             self["type_changes"].append(
-                "%s: %s=%s ===> %s=%s" % (parent, t1, self.__gettype(t1), t2, self.__gettype(t2)))
+                "%s: %s=%s ===> %s=%s" % (parent, self.__getvalue(t1), self.__gettype(t1), self.__getvalue(t2), self.__gettype(t2)))
 
         elif isinstance(t1, (basestring, bytes)):
             self.__diff_str(t1, t2, parent)

--- a/deepdiff/deepdiff.py
+++ b/deepdiff/deepdiff.py
@@ -119,8 +119,8 @@ class DeepDiff(dict):
         >>>
         >>> print (ddiff['values_changed'][0])
         root[4]['b']:
-        ---
-        +++
+        --- 
+        +++ 
         @@ -1,5 +1,4 @@
         -world!
         -Goodbye!

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,6 +8,8 @@ python -m unittest discover
 
 import unittest
 from decimal import Decimal
+from sys import version
+py3 = version[0] == '3'
 
 from deepdiff import DeepDiff
 
@@ -254,7 +256,7 @@ class DeepDiffTestCase(unittest.TestCase):
         unicodeString = {"hello": u"你好"}
         asciiString = {"hello": "你好"}
         ddiff = DeepDiff(unicodeString, asciiString)
-        if type(unicodeString["hello"]) == str:
+        if py3:
             # In python3, all string is unicode, so diff is empty
             result = {}
         else:
@@ -266,7 +268,7 @@ class DeepDiffTestCase(unittest.TestCase):
         unicodeString = {"hello": u"你好"}
         asciiString = {"hello": u"你好hello"}
         ddiff = DeepDiff(unicodeString, asciiString)
-        if type(unicodeString["hello"]) == str:
+        if py3:
             result = {'values_changed': ["root['hello']: '你好' ===> '你好hello'"]}
         else:
             result = {'values_changed': [u"root['hello']: '\u4f60\u597d' ===> '\u4f60\u597dhello'"]}
@@ -276,7 +278,7 @@ class DeepDiffTestCase(unittest.TestCase):
         unicodeString = {"hello": u"你好"}
         asciiString = {"hello": "你好hello"}
         ddiff = DeepDiff(unicodeString, asciiString)
-        if type(unicodeString["hello"]) == str:
+        if py3:
             # In python3, all string is unicode, so these 2 strings only diff in values
             result = {'values_changed': ["root['hello']: '你好' ===> '你好hello'"]}
         else:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -250,3 +250,44 @@ class DeepDiffTestCase(unittest.TestCase):
         result = {}
         self.assertEqual(ddiff, result)
 
+    def test_unicode_string_type_changes(self):
+        unicodeString = {"hello": u"你好"}
+        asciiString = {"hello": "你好"}
+        ddiff = DeepDiff(unicodeString, asciiString)
+        if type(unicodeString["hello"]) == str:
+            # In python3, all string is unicode, so diff is empty
+            result = {}
+        else:
+            # In python2, these are 2 different type of strings
+            result = {'type_changes': [u"root['hello']: \u4f60\u597d=<type 'unicode'> ===> \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd=<type 'str'>"]}
+        self.assertEqual(ddiff, result)
+
+    def test_unicode_string_value_changes(self):
+        unicodeString = {"hello": u"你好"}
+        asciiString = {"hello": u"你好hello"}
+        ddiff = DeepDiff(unicodeString, asciiString)
+        if type(unicodeString["hello"]) == str:
+            result = {'values_changed': ["root['hello']: '你好' ===> '你好hello'"]}
+        else:
+            result = {'values_changed': [u"root['hello']: '\u4f60\u597d' ===> '\u4f60\u597dhello'"]}
+        self.assertEqual(ddiff, result)
+
+    def test_unicode_string_value_and_type_changes(self):
+        unicodeString = {"hello": u"你好"}
+        asciiString = {"hello": "你好hello"}
+        ddiff = DeepDiff(unicodeString, asciiString)
+        if type(unicodeString["hello"]) == str:
+            # In python3, all string is unicode, so these 2 strings only diff in values
+            result = {'values_changed': ["root['hello']: '你好' ===> '你好hello'"]}
+        else:
+            # In python2, these are 2 different type of strings
+            result = {'type_changes': [u"root['hello']: \u4f60\u597d=<type 'unicode'> ===> \ufffd\ufffd\ufffd\ufffd\ufffd\ufffdhello=<type 'str'>"]}
+        self.assertEqual(ddiff, result)
+
+    def test_unicode_string_value_and_type_not_changes(self):
+        unicodeString = {"hello": u"你好"}
+        asciiString = {"hello": u"你好"}
+        ddiff = DeepDiff(unicodeString, asciiString)
+        result = {}
+        self.assertEqual(ddiff, result)
+


### PR DESCRIPTION
Change-Id: I24919e1dba94a85a73dba2cd3adba04b88d49fce

Hi,

When I use DeepDiff, it throws UnicodeDecodeError. I pull this request to solve that. Verified in my local space.

This is my first pull request in github, please correct me if I did something wrong. Thanks.

This is the Trace:
```
   ... Above is my code
    ddiff = DeepDiff(noad_original[i], pack_data[pack_index])
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 214, in __init__
    self.__diff(t1, t2, parents_ids=frozenset({id(t1)}))
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 378, in __diff
    self.__diff_dict(t1, t2, parent, parents_ids)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 278, in __diff_dict
    self.__diff_common_children(t1, t2, t_keys_intersect, print_as_attribute, parents_ids, parent, parent_text)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 301, in __diff_common_children
    self.__diff(t1_child, t2_child, parent=parent_text % (parent, item_key_str), parents_ids=parents_added)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 403, in __diff
    self.__diff_iterable(t1, t2, parent, parents_ids)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 328, in __diff_iterable
    self.__diff(x, y, "%s[%s]" % (parent, i), parents_ids)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 378, in __diff
    self.__diff_dict(t1, t2, parent, parents_ids)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 278, in __diff_dict
    self.__diff_common_children(t1, t2, t_keys_intersect, print_as_attribute, parents_ids, parent, parent_text)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 301, in __diff_common_children
    self.__diff(t1_child, t2_child, parent=parent_text % (parent, item_key_str), parents_ids=parents_added)
  File "/data02/home/wangfenjin/repos/pyutil/pyutil/deepdiff/deepdiff/deepdiff.py", line 368, in __diff
    "%s: %s=%s ===> %s=%s" % (parent, t1, self.__gettype(t1), t2, self.__gettype(t2)))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe9 in position 33: ordinal not in range(128)
```