### PR TITLE
Added Travis-CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+
+sudo: false
+
+script: nosetests


### PR DESCRIPTION
Example: https://travis-ci.org/nfvs/deepdiff

I tried enabling testing with pypy as well, but there were a few test failures, but all related to the way lists are converted to strings. It seems pypy sometimes reverses the lists (`[5, 3]` instead of `[3, 5]`), which causes failures. I wonder if that's something worth worrying about.