### PR TITLE
Significant_digits option for float comparison

### DIFF
--- a/deepdiff/deepdiff.py
+++ b/deepdiff/deepdiff.py
@@ -285,8 +285,9 @@ class DeepDiff(dict):
     def __init__(self, t1, t2, ignore_order=False, report_repetition=False, significant_digits=None):
         self.ignore_order = ignore_order
         self.report_repetition = report_repetition
-        if significant_digits is not None and significant_digits<0:
-            raise ValueError("significant_digits must be None or a non-negative integer")
+        if significant_digits is not None:
+            if significant_digits<0:
+                raise ValueError("significant_digits must be None or a non-negative integer")
         self.significant_digits=significant_digits
 
         self.update({"type_changes": {}, "dic_item_added": set([]), "dic_item_removed": set([]),

--- a/deepdiff/deepdiff.py
+++ b/deepdiff/deepdiff.py
@@ -82,9 +82,13 @@ class DeepDiff(dict):
         Normally ignore_order does not report duplicates and repetition changes.
         In order to report repetitions, set report_repetition=True in addition to ignore_order=True
 
-    report_repetition : Boolean, defalt=False reports repetitions when set True
+    report_repetition : Boolean, default=False reports repetitions when set True
         ONLY when ignore_order is set True too. This works for iterables.
 
+
+    significant_digits: None or in`>=0. If it is an int, compare only that many digits after 
+        the decimal point. This only affects floats, decimal.Decimal and complex.
+        
     **Returns**
 
         A DeepDiff object that has already calculated the difference of the 2 items.
@@ -265,11 +269,25 @@ class DeepDiff(dict):
         >>> pprint(DeepDiff(t1, t2))
         {'attribute_added': {'root.c'},
          'values_changed': {'root.b': {'newvalue': 2, 'oldvalue': 1}}}
+
+    Approximate float comparison:
+        >>> t1 = [ 1.1129, 1.3359 ]
+        >>> t2 = [ 1.113, 1.3362 ]
+        >>> pprint(DeepDiff(t1, t2, significant_digits=3))
+        {}
+        >>> pprint(DeepDiff(t1, t2))
+        {'values_changed': {'root[0]': {'newvalue': 1.113, 'oldvalue': 1.1129},
+                            'root[1]': {'newvalue': 1.3362, 'oldvalue': 1.3359}}}
+        >>> pprint(DeepDiff(1.23*10**20, 1.24*10**20, significant_digits=1))
+        {'values_changed': {'root': {'newvalue': 1.24e+20, 'oldvalue': 1.23e+20}}}
     """
 
-    def __init__(self, t1, t2, ignore_order=False, report_repetition=False):
+    def __init__(self, t1, t2, ignore_order=False, report_repetition=False, significant_digits=None):
         self.ignore_order = ignore_order
         self.report_repetition = report_repetition
+        if significant_digits is not None and significant_digits<0:
+            raise ValueError("significant_digits must be None or a non-negative integer")
+        self.significant_digits=significant_digits
 
         self.update({"type_changes": {}, "dic_item_added": set([]), "dic_item_removed": set([]),
                      "values_changed": {}, "unprocessed": [], "iterable_item_added": {}, "iterable_item_removed": {},
@@ -510,9 +528,25 @@ class DeepDiff(dict):
             self.__diff_str(t1, t2, parent)
 
         elif isinstance(t1, numbers):
-            if t1 != t2:
-                self["values_changed"][parent] = {
-                    "oldvalue": t1, "newvalue": t2}
+            if isinstance(t1, (float, complex, Decimal)) and self.significant_digits is not None:
+                # I use string formatting for comparison, to be consistent with usecases where 
+                # data is read from files that were previousely written from python and
+                # to be consistent with on-screen representation of numbers.
+                # Other options would be abs(t1-t2)<10**-self.significant_digits
+                # or math.is_close (python3.5+)
+                # Note that abs(3.25-3.251) = 0.0009999999999998899 < 0.001
+                # Note also that "{:.3f}".format(1.1135) = 1.113, but "{:.3f}".format(1.11351) = 1.114
+                # For Decimals, format seems to round 2.5 to 2 and 3.5 to 4 (to closest even number)
+                t1_s=("{:."+str(self.significant_digits)+"f}").format(t1)
+                t2_s=("{:."+str(self.significant_digits)+"f}").format(t2)
+                if t1_s!=t2_s:
+                    self["values_changed"][parent] = {
+                        "oldvalue": t1, "newvalue": t2}
+            else:
+                if t1 != t2:
+                    self["values_changed"][parent] = {
+                        "oldvalue": t1, "newvalue": t2}
+
 
         elif isinstance(t1, MutableMapping):
             self.__diff_dict(t1, t2, parent, parents_ids)

--- a/deepdiff/deepdiff.py
+++ b/deepdiff/deepdiff.py
@@ -86,7 +86,7 @@ class DeepDiff(dict):
         ONLY when ignore_order is set True too. This works for iterables.
 
 
-    significant_digits: None or in`>=0. If it is an int, compare only that many digits after 
+    significant_digits: None or int>=0. If it is an int, compare only that many digits after 
         the decimal point. This only affects floats, decimal.Decimal and complex.
         
     **Returns**

--- a/tests.py
+++ b/tests.py
@@ -483,3 +483,40 @@ class DeepDiffTestCase(unittest.TestCase):
                                        {'oldtype': int, 'newvalue': u'\u4f60\u597d',
                                         'oldvalue': 1, 'newtype': unicode}}}
         self.assertEqual(ddiff, result)
+
+    def test_significant_digits_for_decimals(self):
+        t1=Decimal('2.5')
+        t2=Decimal('1.5')
+        ddiff = DeepDiff(t1, t2, significant_digits=0)
+        self.assertEqual(ddiff, {})
+
+    def test_significant_digits_for_complex_imaginary_part(self):
+        t1=1.23+1.222254j
+        t2=1.23+1.222256j
+        ddiff = DeepDiff(t1, t2, significant_digits=4)
+        self.assertEqual(ddiff, {})
+        result = {'values_changed': {'root': {'newvalue': (1.23+1.222256j), 'oldvalue': (1.23+1.222254j)}}}
+        ddiff = DeepDiff(t1, t2, significant_digits=5)
+        self.assertEqual(ddiff, result)
+    def test_significant_digits_for_complex_real_part(self):
+        t1=1.23446879+1.22225j
+        t2=1.23446764+1.22225j
+        ddiff = DeepDiff(t1, t2, significant_digits=5)
+        self.assertEqual(ddiff, {})
+
+    def test_significant_digits_for_list_of_floats(self):
+        t1=[1.2344, 5.67881, 6.778879]
+        t2=[1.2343, 5.67882, 6.778878]
+        ddiff = DeepDiff(t1, t2, significant_digits=3)
+        self.assertEqual(ddiff, {})
+        ddiff = DeepDiff(t1, t2, significant_digits=4)
+        result= {'values_changed': {'root[0]': {'newvalue': 1.2343, 'oldvalue': 1.2344}}}
+        self.assertEqual(ddiff, result)
+        ddiff = DeepDiff(t1, t2, significant_digits=5)
+        result= {'values_changed': {'root[0]': {'newvalue': 1.2343, 'oldvalue': 1.2344}, 
+                                    'root[1]': {'newvalue': 5.67882, 'oldvalue': 5.67881}}}
+        self.assertEqual(ddiff, result)
+        ddiff = DeepDiff(t1, t2)
+        ddiff2 = DeepDiff(t1, t2, significant_digits=6)
+        self.assertEqual(ddiff, ddiff2)
+


### PR DESCRIPTION
For comparison of floats that represent the same value but were generated differently, it is often useful to compare if they are almost the same.

I implemented an option called `significant_digits` for comparison of `float`, `complex`  and `Decimal` values. If 2 floats share the same significant digits AFTER the decimal point, they compare equal if this option is provided.

It works via the string.format method (other options would have been using the absolute or relative difference).

See also: PEP0485 for other implementations of the `is_close` concept.
