### PR TITLE
Exclusion patterns

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,4 +9,4 @@ Thanks to:
     * timoilya for comparing list of sets when ignoring order.
     * Bernhard10 for significant digits comparison.
     * b-jazz for PEP257 cleanup, Standardize on full names, fixing line endings.
-    * Victor Hahn Castell @ Flexoptix for deep set comparison
+    * Victor Hahn Castell @ Flexoptix for deep set comparison and exclusion patterns

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# deepdiff v 1.7.0
+# deepdiff v 1.8.0
 
 <!-- ![Downloads](https://img.shields.io/pypi/dm/deepdiff.svg?style=flat) -->
 ![Python Versions](https://img.shields.io/pypi/pyversions/deepdiff.svg?style=flat)
@@ -334,6 +334,7 @@ Example in DeepDiff for the same operation:
 
 ##Changelog
 
+- v1-8-0: Exclusion patterns
 - v1-7-0: Deep Set comparison
 - v1-6-0: Unifying key names. i.e newvalue is new_value now. For backward compatibility, newvalue still works.
 - v1-5-0: Fixing ignore order containers with unordered items. Adding significant digits when comparing decimals. Changes property is deprecated.
@@ -367,4 +368,4 @@ Thanks to:
 - timoilya for comparing list of sets when ignoring order.
 - Bernhard10 for significant digits comparison.
 - b-jazz for PEP257 cleanup, Standardize on full names, fixing line endings.
-- Victor Hahn Castell @ Flexoptix for deep set comparison and exclusion patterns
+- [Victor Hahn Castell](http://hahncastell.de) @ [Flexoptix](http://www.flexoptix.net) for deep set comparison and exclusion patterns

--- a/README.md
+++ b/README.md
@@ -256,6 +256,24 @@ Although `ignore_order` flag uses hash of items to calculate what is added or re
  'values_changed': {'root.b': {'new_value': 2, 'old_value': 1}}}
 ```
 
+### Exclude certain types from comparison:
+```python
+>>> l1 = logging.getLogger("test")
+>>> l2 = logging.getLogger("test2")
+>>> t1 = {"log": l1, 2: 1337}
+>>> t2 = {"log": l2, 2: 1337}
+>>> print(DeepDiff(t1, t2, exclude_types={logging.Logger}))
+{}
+```
+
+### Exclude part of your object tree from comparison:
+```python
+>>> t1 = {"for life": "vegan", "ingredients": ["no meat", "no eggs", "no dairy"]}
+>>> t2 = {"for life": "vegan", "ingredients": ["veggies", "tofu", "soy sauce"]}
+>>> print (DeepDiff(t1, t2, exclude_paths={"root['ingredients']"}))
+{}
+```
+
 ### Significant Digits
 
 Digits **after** the decimal point. Internally it uses "{:.Xf}".format(Your Number) to compare numbers where X=significant_digits
@@ -349,4 +367,4 @@ Thanks to:
 - timoilya for comparing list of sets when ignoring order.
 - Bernhard10 for significant digits comparison.
 - b-jazz for PEP257 cleanup, Standardize on full names, fixing line endings.
-- Victor Hahn Castell @ Flexoptix for deep set comparison
+- Victor Hahn Castell @ Flexoptix for deep set comparison and exclusion patterns

--- a/README.txt
+++ b/README.txt
@@ -184,6 +184,20 @@ Object attribute added:
     {'attribute_added': ['root.c'],
      'values_changed': {'root.b': {'new_value': 2, 'old_value': 1}}}
 
+Exclude certain types from comparison:
+    >>> l1 = logging.getLogger("test")
+    >>> l2 = logging.getLogger("test2")
+    >>> t1 = {"log": l1, 2: 1337}
+    >>> t2 = {"log": l2, 2: 1337}
+    >>> print(DeepDiff(t1, t2, exclude_types={logging.Logger}))
+    {}
+
+Exclude part of your object tree from comparison:
+    >>> t1 = {"for life": "vegan", "ingredients": ["no meat", "no eggs", "no dairy"]}
+    >>> t2 = {"for life": "vegan", "ingredients": ["veggies", "tofu", "soy sauce"]}
+    >>> print (DeepDiff(t1, t2, exclude_paths={"root['ingredients']"}))
+    {}
+
 
 Using DeepDiff in unit tests
 result is the output of the function that is being tests.
@@ -242,4 +256,4 @@ Thanks to:
 - timoilya for comparing list of sets when ignoring order
 - Bernhard10 for significant digits comparison
 - b-jazz for PEP257 cleanup, Standardize on full names, fixing line endings.
-- Victor Hahn Castell @ Flexoptix for deep set comparison
+- Victor Hahn Castell @ Flexoptix for deep set comparison and exclusion patterns

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-**DeepDiff v 1.7.0**
+**DeepDiff v 1.8.0**
 
 Deep Difference of dictionaries, iterables, strings and other objects. It will recursively look for all the changes.
 
@@ -223,6 +223,7 @@ Example in DeepDiff for the same operation:
 
 **Changelog**
 
+- v1-8-0: Exclusion patterns
 - v1-7-0: Deep Set comparison
 - v1-6-0: Unifying key names. i.e newvalue is new_value now. For backward compatibility, newvalue still works.
 - v1-5-0: Fixing ignore order containers with unordered items. Adding significant digits when comparing decimals. Changes property is deprecated.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except:
     long_description = "Deep Difference of dictionaries, iterables, strings and other objects. It will recursively look for all the changes."
 
 setup(name='deepdiff',
-      version='1.7.0',
+      version='1.8.0',
       description='Deep Difference of dictionaries, iterables, strings and other objects. It will recursively look for all the changes.',
       url='https://github.com/seperman/deepdiff',
       download_url='https://github.com/seperman/deepdiff/tarball/master',

--- a/tests.py
+++ b/tests.py
@@ -710,3 +710,38 @@ class DeepDiffTestCase(unittest.TestCase):
                          ddiff['type_changes']['root[2]']['old_type'])
         self.assertEqual(ddiff['type_changes']['root[2]']['oldvalue'],
                          ddiff['type_changes']['root[2]']['old_value'])
+
+    def test_skip_type(self):
+        l1 = logging.getLogger("test")
+        l2 = logging.getLogger("test2")
+        t1 = {"log": l1, 2: 1337}
+        t2 = {"log": l2, 2: 1337}
+        ddiff = DeepDiff(t1, t2, exclude_types={logging.Logger})
+        self.assertEqual(ddiff, {})
+
+        t1 = {"log": "book", 2: 1337}
+        t2 = {"log": l2, 2: 1337}
+        ddiff = DeepDiff(t1, t2, exclude_types={logging.Logger})
+        self.assertEqual(ddiff, {})
+
+    def test_skip_path(self):
+        t1 = {"for life": "vegan", "ingredients": ["no meat", "no eggs", "no dairy"]}
+        t2 = {"for life": "vegan", "ingredients": ["veggies", "tofu", "soy sauce"]}
+        ddiff = DeepDiff(t1, t2, exclude_paths={"root['ingredients']"})
+        self.assertEqual(ddiff, {})
+
+        t1 = {"for life": "vegan", "ingredients": ["no meat", "no eggs", "no dairy"]}
+        t2 = {"for life": "vegan"}
+        ddiff = DeepDiff(t1, t2, exclude_paths={"root['ingredients']"})
+        self.assertEqual(ddiff, {})
+
+        t1 = {"for life": "vegan", "ingredients": ["no meat", "no eggs", "no dairy"]}
+        t2 = {"for life": "vegan"}
+        ddiff = DeepDiff(t2, t1, exclude_paths={"root['ingredients']"})
+        self.assertEqual(ddiff, {})
+
+        t1 = {"for life": "vegan", "ingredients": ["no meat", "no eggs", "no dairy"]}
+        t2 = {"for life": "vegan", "zutaten": ["veggies", "tofu", "soy sauce"]}
+        ddiff = DeepDiff(t1, t2, exclude_paths={"root['ingredients']"})
+        self.assertTrue('dictionary_item_added' in ddiff, {})
+        self.assertTrue('dictionary_item_removed' not in ddiff, {})


### PR DESCRIPTION
Allows to exclude specific parts of an object tree from comparison.

I took the liberty of including a version bump -- if that doesn't fit your versioning scheme, I'll nuke that commit.