### PR TITLE
Prevent logging config from screwing with root logger when DeepDiff is used as a lib

### DIFF
--- a/deepdiff/__init__.py
+++ b/deepdiff/__init__.py
@@ -1,2 +1,9 @@
+import logging
+
+
+if __name__ == '__main__':
+    logging.basicConfig(format='%(asctime)s %(levelname)8s %(message)s')
+
+
 from .diff import DeepDiff
 from .search import DeepSearch

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -35,8 +35,7 @@ else:  # pragma: no cover
     from itertools import izip_longest as zip_longest
     items = 'iteritems'
 
-logging.basicConfig(format='%(asctime)s %(levelname)8s %(message)s')
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 IndexedHash = namedtuple('IndexedHash', 'indexes item')
 
@@ -613,8 +612,8 @@ class DeepDiff(RemapDict):
                 cleaned_item = order_unordered(item)
                 item_hash = hash(pickle.dumps(cleaned_item))
             except:  # pragma: no cover
-                logger.error("Can not produce a hash for %s item in %s and "
-                             "thus not counting this object." % (item, parent), exc_info=True)
+                logger.warning("Can not produce a hash for %s item in %s and "
+                               "thus not counting this object." % (item, parent), exc_info=True)
             else:
                 add_hash(hashes, item_hash, item, i)
         return hashes

--- a/deepdiff/search.py
+++ b/deepdiff/search.py
@@ -27,8 +27,7 @@ else:  # pragma: no cover
     numbers = (int, float, long, complex, datetime.datetime, datetime.date, Decimal)
     items = 'iteritems'
 
-logging.basicConfig(format='%(asctime)s %(levelname)8s %(message)s')
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 INDEX_VS_ATTRIBUTE = ('[%s]', '.%s')


### PR DESCRIPTION
Hi,

We've started using DeepDiff for a specific use case as a library / imported within a larger application and noticed a few logging issues which we've pinpointed to DeepDiff as being the cause.

More specifically, this line:
`logging.basicConfig(format='%(asctime)s %(levelname)8s %(message)s')`

This pull request isolates this away in a way that it will still be used when using DeepDiff by itself, but not when used by importing it inside another app.