### PR TITLE
Bugfix for significant_digits (signed zero); Numpy-friendlyness; Issue #49; Failing tests for #50;

### DIFF
--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -15,7 +15,7 @@ import logging
 
 from decimal import Decimal
 
-from collections import MutableMapping
+from collections import Mapping
 from collections import Iterable
 
 from deepdiff.helper import py3, strings, numbers, ListItemRemovedOrAdded, IndexedHash, Verbose
@@ -672,7 +672,7 @@ class DeepDiff(ResultDict):
         elif isinstance(level.t1, numbers):
             self.__diff_numbers(level)
 
-        elif isinstance(level.t1, MutableMapping):
+        elif isinstance(level.t1, Mapping):
             self.__diff_dict(level, parents_ids)
 
         elif isinstance(level.t1, tuple):

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -640,7 +640,11 @@ class DeepDiff(ResultDict):
             # For Decimals, format seems to round 2.5 to 2 and 3.5 to 4 (to closest even number)
             t1_s = ("{:.%sf}" % self.significant_digits).format(level.t1)
             t2_s = ("{:.%sf}" % self.significant_digits).format(level.t2)
-            if t1_s != t2_s:
+            
+            # Special case for 0: "-0.00" should compare equal to "0.00"
+            if set(t1_s)<=set("-0.") and set(t2_s)<=set("-0."):
+                return
+            elif t1_s != t2_s:
                 self.__report_result('values_changed', level)
         else:
             if level.t1 != level.t2:

--- a/deepdiff/model.py
+++ b/deepdiff/model.py
@@ -305,12 +305,13 @@ class DiffLevel(object):
         :param param: A ChildRelationship subclass-dependent parameter describing how to get from parent to child,
                       e.g. the key in a dict
         """
-        if self.down.t1:
+        if self.down.t1 is not None:
             self.t1_child_rel = ChildRelationship.create(klass=klass, parent=self.t1,
                                                          child=self.down.t1, param=param)
-        if self.down.t2:
+        if self.down.t2 is not None:
             self.t2_child_rel = ChildRelationship.create(klass=klass, parent=self.t2,
                                                          child=self.down.t2, param=param)
+
 
     @property
     def all_up(self):

--- a/tests/test_diff_ref.py
+++ b/tests/test_diff_ref.py
@@ -18,6 +18,7 @@ To run a specific test, run this from the root of repo:
     python -m unittest tests.test_diff_ref.DeepDiffRefTestCase.test_same_objects
 """
 import unittest
+import platform
 from deepdiff import DeepDiff
 from deepdiff.model import DictRelationship, NonSubscriptableIterableRelationship
 
@@ -147,6 +148,7 @@ class DeepDiffRefTestCase(unittest.TestCase):
         ddiff = DeepDiff([0.012, 0.98], [0.013, 0.99], significant_digits = 1, ignore_order=True)
         self.assertEqual(ddiff, {})
 
+@unittest.skipIf(platform.python_implementation() == "PyPy", "Numpy is not the same under PyPy")
 class DeepDiffRefWithNumpyTestCase(unittest.TestCase):
 
     """DeepDiff Tests."""

--- a/tests/test_diff_ref.py
+++ b/tests/test_diff_ref.py
@@ -133,6 +133,18 @@ class DeepDiffRefTestCase(unittest.TestCase):
         self.assertEqual(change.path(force='yes'), 'root(unrepresentable)')
         self.assertEqual(change.path(force='fake'), 'root[2]')
 
+    def test_significant_digits(self):
+        ddiff = DeepDiff([0.012, 0.98], [0.013, 0.99], significant_digits = 1)
+        self.assertEqual(ddiff, {})
+        
+    def test_significant_digits_with_sets(self):
+        ddiff = DeepDiff(set([0.012, 0.98]), set([0.013, 0.99]), significant_digits = 1)
+        self.assertEqual(ddiff, {})
+        
+    def test_significant_digits_with_ignore_order(self):
+        ddiff = DeepDiff([0.012, 0.98], [0.013, 0.99], significant_digits = 1, ignore_order=True)
+        self.assertEqual(ddiff, {})
+
 class DeepDiffRefWithNumpyTestCase(unittest.TestCase):
 
     """DeepDiff Tests."""

--- a/tests/test_diff_ref.py
+++ b/tests/test_diff_ref.py
@@ -18,7 +18,6 @@ To run a specific test, run this from the root of repo:
     python -m unittest tests.test_diff_ref.DeepDiffRefTestCase.test_same_objects
 """
 import unittest
-import platform
 from deepdiff import DeepDiff
 from deepdiff.model import DictRelationship, NonSubscriptableIterableRelationship
 
@@ -148,7 +147,6 @@ class DeepDiffRefTestCase(unittest.TestCase):
         ddiff = DeepDiff([0.012, 0.98], [0.013, 0.99], significant_digits = 1, ignore_order=True)
         self.assertEqual(ddiff, {})
 
-@unittest.skipIf(platform.python_implementation() == "PyPy", "Numpy is not the same under PyPy")
 class DeepDiffRefWithNumpyTestCase(unittest.TestCase):
 
     """DeepDiff Tests."""

--- a/tests/test_diff_ref.py
+++ b/tests/test_diff_ref.py
@@ -36,6 +36,19 @@ class DeepDiffRefTestCase(unittest.TestCase):
         res = ddiff.tree
         self.assertEqual(res, {})
 
+    def test_significant_digits_signed_zero(self):
+        t1 = 0.00001
+        t2 = -0.0001
+        ddiff = DeepDiff(t1, t2, significant_digits = 2)
+        res = ddiff.tree
+        self.assertEqual(res, {})
+        t1 = 1*10**-12
+        t2 = -1*10**-12
+        ddiff = DeepDiff(t1, t2, significant_digits=10)
+        res = ddiff.tree
+        self.assertEqual(res, {})
+
+        
     def test_item_added_extensive(self):
         t1 = {'one': 1, 'two': 2, 'three': 3, 'four': 4}
         t2 = {'one': 1, 'two': 2, 'three': 3, 'four': 4, 'new': 1337}

--- a/tests/test_diff_ref.py
+++ b/tests/test_diff_ref.py
@@ -121,6 +121,7 @@ class DeepDiffRefTestCase(unittest.TestCase):
         self.assertIsInstance(change.up.t1_child_rel, NonSubscriptableIterableRelationship)
         self.assertIsNone(change.up.t2_child_rel)
 
+
     def test_non_subscriptable_iterable_path(self):
         t1 = (i for i in [42, 1337, 31337])
         t2 = (i for i in [42, 1337, ])
@@ -131,3 +132,26 @@ class DeepDiffRefTestCase(unittest.TestCase):
         self.assertEqual(change.path(), None)
         self.assertEqual(change.path(force='yes'), 'root(unrepresentable)')
         self.assertEqual(change.path(force='fake'), 'root[2]')
+
+class DeepDiffRefWithNumpyTestCase(unittest.TestCase):
+
+    """DeepDiff Tests."""
+    def setUp(self):
+        import numpy as np
+        a1 = np.array([1.23, 1.66, 1.98])
+        a2 = np.array([1.23, 1.66, 1.98])
+        self.d1 = { 'np': a1 }
+        self.d2 = { 'np': a2 }
+        
+    def test_diff_with_numpy(self):
+        ddiff = DeepDiff(self.d1, self.d2)
+        res = ddiff.tree
+        self.assertEqual(res, {})
+        
+    def test_diff_with_empty_seq(self):
+        a1 = {"empty":[]}
+        a2 = {"empty":[]}
+        ddiff = DeepDiff(a1, a2)
+        res = ddiff.tree
+        self.assertEqual(ddiff, {})
+

--- a/tests/test_diff_ref.py
+++ b/tests/test_diff_ref.py
@@ -136,11 +136,13 @@ class DeepDiffRefTestCase(unittest.TestCase):
     def test_significant_digits(self):
         ddiff = DeepDiff([0.012, 0.98], [0.013, 0.99], significant_digits = 1)
         self.assertEqual(ddiff, {})
-        
+
+    @unittest.expectedFailure    
     def test_significant_digits_with_sets(self):
         ddiff = DeepDiff(set([0.012, 0.98]), set([0.013, 0.99]), significant_digits = 1)
         self.assertEqual(ddiff, {})
-        
+
+    @unittest.expectedFailure
     def test_significant_digits_with_ignore_order(self):
         ddiff = DeepDiff([0.012, 0.98], [0.013, 0.99], significant_digits = 1, ignore_order=True)
         self.assertEqual(ddiff, {})


### PR DESCRIPTION
This pullrequests makes several small changes. Fell free to merge only selected commits if desired.
Most commit contain changes to the main source code and tests.

-  I add 2 failing tests to document issue #50 
- I compare `self.down.t1` to None instead of using `if self.down.ta` in `auto_generate_child_rel`, because numpy arrays rise an error when used as booleans. I hope this changed behaviour does not introduce any bugs with other edge-cases.
-  I added a bugfix to `__diff_numbers` for the significant_digits option. Now -0 and +0 compare equal.
-  Finally I use `__diff_dict` instead of `__diff_iterable` for the comparison of `collections.abc.Mapping` instances (before `__diff_dict` required the container to be a `MutableMapping`) - see issue #49