### PR TITLE
Handle __slots__ being a string or containing name mangled attributes

### DIFF
--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -735,6 +735,21 @@ class DeepDiffTextTestCase(unittest.TestCase):
         }
         self.assertEqual(ddiff, result)
 
+    def test_custom_objects_with_single_protected_slot(self):
+        class ClassA(object):
+            __slots__ = '__a'
+
+            def __init__(self):
+                self.__a = 1
+
+            def __str__(self):
+                return str(self.__a)
+
+        t1 = ClassA()
+        t2 = ClassA()
+        diff = DeepDiff(t1, t2)
+        self.assertEqual(diff, {})
+
     def get_custom_objects_add_and_remove(self):
         class ClassA(object):
             a = 1


### PR DESCRIPTION
I had a problem with a class with:
`__slots__ = '__id'`

There are two things the existing code can't handle:
1. There is only one slot and it is defined as a single string so the current code iterates through the string.
1. The attribute is mangled so `getattr(t1, '__id')` fails

My first fix for this was to add a command line option to add a list of types which DeepDiff should compare with a simple `==`. I called the argument `simple_comparison_types` and it might be a useful idea for people to be able to bypass deepdiff on any custom objects it can't yet handle?

I've submitted my patch against your 'dev' branch since you've got some fairly major changes in the works although this patch is completely independent anyway.