### PR TITLE
BF+TST: Fix issues with bytes/unicode when diffing text (issue #60)

### DIFF
--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -19,7 +19,7 @@ from decimal import Decimal
 from collections import Mapping
 from collections import Iterable
 
-from deepdiff.helper import py3, strings, numbers, ListItemRemovedOrAdded, notpresent, IndexedHash, Verbose
+from deepdiff.helper import py3, strings, bytes_type, numbers, ListItemRemovedOrAdded, notpresent, IndexedHash, Verbose
 from deepdiff.model import RemapDict, ResultDict, TextResult, TreeResult, DiffLevel
 from deepdiff.model import DictRelationship, AttributeRelationship  # , REPORT_KEYS
 from deepdiff.model import SubscriptableIterableRelationship, NonSubscriptableIterableRelationship, SetRelationship
@@ -901,14 +901,24 @@ class DeepDiff(ResultDict):
         """Compare strings"""
         if level.t1 == level.t2:
             return
-
+        
         # do we add a diff for convenience?
-        if '\n' in level.t1 or '\n' in level.t2:
+        do_diff = True
+        if isinstance(level.t1, bytes_type):
+            try:
+                t1_str = level.t1.decode('ascii')
+                t2_str = level.t2.decode('ascii')
+            except UnicodeDecodeError:
+                do_diff = False
+        else:
+            t1_str = level.t1
+            t2_str = level.t2
+        if do_diff and u'\n' in t1_str or u'\n' in t2_str:
             diff = difflib.unified_diff(
-                level.t1.splitlines(), level.t2.splitlines(), lineterm='')
+                t1_str.splitlines(), t2_str.splitlines(), lineterm='')
             diff = list(diff)
             if diff:
-                level.additional['diff'] = '\n'.join(diff)
+                level.additional['diff'] = u'\n'.join(diff)
 
         self.__report_result('values_changed', level)
 

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -913,12 +913,13 @@ class DeepDiff(ResultDict):
         else:
             t1_str = level.t1
             t2_str = level.t2
-        if do_diff and u'\n' in t1_str or u'\n' in t2_str:
-            diff = difflib.unified_diff(
-                t1_str.splitlines(), t2_str.splitlines(), lineterm='')
-            diff = list(diff)
-            if diff:
-                level.additional['diff'] = u'\n'.join(diff)
+        if do_diff:
+            if u'\n' in t1_str or u'\n' in t2_str:
+                diff = difflib.unified_diff(
+                    t1_str.splitlines(), t2_str.splitlines(), lineterm='')
+                diff = list(diff)
+                if diff:
+                    level.additional['diff'] = u'\n'.join(diff)
 
         self.__report_result('values_changed', level)
 

--- a/deepdiff/helper.py
+++ b/deepdiff/helper.py
@@ -20,11 +20,15 @@ pypy3 = py3 and hasattr(sys, "pypy_translation_info")
 if py3:  # pragma: no cover
     from builtins import int
     strings = (str, bytes)  # which are both basestring
+    unicode_type = str
+    bytes_type = bytes
     numbers = (int, float, complex, datetime.datetime, datetime.date, Decimal)
     items = 'items'
 else:  # pragma: no cover
     int = int
     strings = (str, unicode)
+    unicode_type = unicode
+    bytes_type = str
     numbers = (int, float, long, complex, datetime.datetime, datetime.date,
                Decimal)
 

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -23,7 +23,7 @@ import unittest
 import datetime
 from decimal import Decimal
 from deepdiff import DeepDiff
-from deepdiff.helper import py3
+from deepdiff.helper import py3, bytes_type
 from tests import CustomClass
 if py3:
     from unittest import mock
@@ -173,6 +173,54 @@ class DeepDiffTextTestCase(unittest.TestCase):
                     '--- \n+++ \n@@ -1,5 +1,4 @@\n-world!\n-Goodbye!\n+world\n 1\n 2\n End',
                     'new_value': 'world\n1\n2\nEnd',
                     'old_value': 'world!\nGoodbye!\n1\n2\nEnd'
+                }
+            }
+        }
+        self.assertEqual(ddiff, result)
+        
+    def test_bytes(self):
+        t1 = {
+            1: 1,
+            2: 2,
+            3: 3,
+            4: {
+                "a": b"hello",
+                "b": b"world!\nGoodbye!\n1\n2\nEnd"
+            }
+        }
+        t2 = {1: 1, 2: 2, 3: 3, 4: {"a": b"hello", "b": b"world\n1\n2\nEnd"}}
+        ddiff = DeepDiff(t1, t2)
+        result = {
+            'values_changed': {
+                "root[4]['b']": {
+                    'diff':
+                    '--- \n+++ \n@@ -1,5 +1,4 @@\n-world!\n-Goodbye!\n+world\n 1\n 2\n End',
+                    'new_value': b'world\n1\n2\nEnd',
+                    'old_value': b'world!\nGoodbye!\n1\n2\nEnd'
+                }
+            }
+        }
+        self.assertEqual(ddiff, result)
+        
+    def test_unicode(self):
+        t1 = {
+            1: 1,
+            2: 2,
+            3: 3,
+            4: {
+                "a": u"hello",
+                "b": u"world!\nGoodbye!\n1\n2\nEnd"
+            }
+        }
+        t2 = {1: 1, 2: 2, 3: 3, 4: {"a": u"hello", "b": u"world\n1\n2\nEnd"}}
+        ddiff = DeepDiff(t1, t2)
+        result = {
+            'values_changed': {
+                "root[4]['b']": {
+                    'diff':
+                    '--- \n+++ \n@@ -1,5 +1,4 @@\n-world!\n-Goodbye!\n+world\n 1\n 2\n End',
+                    'new_value': u'world\n1\n2\nEnd',
+                    'old_value': u'world!\nGoodbye!\n1\n2\nEnd'
                 }
             }
         }

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -185,10 +185,19 @@ class DeepDiffTextTestCase(unittest.TestCase):
             3: 3,
             4: {
                 "a": b"hello",
-                "b": b"world!\nGoodbye!\n1\n2\nEnd"
+                "b": b"world!\nGoodbye!\n1\n2\nEnd",
+                "c": b"\x00",
             }
         }
-        t2 = {1: 1, 2: 2, 3: 3, 4: {"a": b"hello", "b": b"world\n1\n2\nEnd"}}
+        t2 = {1: 1, 
+              2: 2, 
+              3: 3, 
+              4: {
+                  "a": b"hello", 
+                  "b": b"world\n1\n2\nEnd",
+                  "c": b'\x01',
+              }
+        }
         ddiff = DeepDiff(t1, t2)
         result = {
             'values_changed': {
@@ -197,6 +206,10 @@ class DeepDiffTextTestCase(unittest.TestCase):
                     '--- \n+++ \n@@ -1,5 +1,4 @@\n-world!\n-Goodbye!\n+world\n 1\n 2\n End',
                     'new_value': b'world\n1\n2\nEnd',
                     'old_value': b'world!\nGoodbye!\n1\n2\nEnd'
+                },
+                "root[4]['c']": {
+                    'new_value': b'\x01',
+                    'old_value': b'\x00'
                 }
             }
         }

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -186,7 +186,7 @@ class DeepDiffTextTestCase(unittest.TestCase):
             4: {
                 "a": b"hello",
                 "b": b"world!\nGoodbye!\n1\n2\nEnd",
-                "c": b"\x00",
+                "c": b"\x80",
             }
         }
         t2 = {1: 1, 
@@ -195,7 +195,7 @@ class DeepDiffTextTestCase(unittest.TestCase):
               4: {
                   "a": b"hello", 
                   "b": b"world\n1\n2\nEnd",
-                  "c": b'\x01',
+                  "c": b'\x81',
               }
         }
         ddiff = DeepDiff(t1, t2)
@@ -208,8 +208,8 @@ class DeepDiffTextTestCase(unittest.TestCase):
                     'old_value': b'world!\nGoodbye!\n1\n2\nEnd'
                 },
                 "root[4]['c']": {
-                    'new_value': b'\x01',
-                    'old_value': b'\x00'
+                    'new_value': b'\x81',
+                    'old_value': b'\x80'
                 }
             }
         }


### PR DESCRIPTION
Code was assuming text is always the default type (bytes in Python2
and unicode in Python3).