### PR TITLE
Fix not searching in inherited class attributes

### DIFF
--- a/deepdiff/search.py
+++ b/deepdiff/search.py
@@ -131,7 +131,10 @@ class DeepSearch(dict):
             if is_namedtuple:
                 obj = obj._asdict()
             else:
-                obj = obj.__dict__
+                # Skip magic methods. Slightly hacky, but unless people are defining
+                # new magic methods they want to search, it should work fine.
+                obj = {i: getattr(obj, i) for i in dir(obj)
+                    if not (i.startswith('__') and i.endswith('__'))}
         except AttributeError:
             try:
                 obj = {i: getattr(obj, i) for i in obj.__slots__}

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -286,6 +286,18 @@ class DeepSearchTestCase(unittest.TestCase):
         result = {'matched_values': {'root'}}
         self.assertEqual(DeepSearch(obj, item, verbose_level=1, case_sensitive=False), result)
 
+    def test_search_inherited_attributes(self):
+        class Parent(object):
+            a = 1
+
+        class Child(Parent):
+            b = 2
+
+        obj = Child()
+        item = 1
+        result = {'matched_values': {'root.a'}}
+        self.assertEqual(DeepSearch(obj, item, verbose_level=1), result)
+
 
 class GrepTestCase(unittest.TestCase):
 


### PR DESCRIPTION
obj.__dict__ doesn't contain all of an object's inherited attributes, whereas dir() does.

Fixes #73 