### PR TITLE
Add an option to search for an exact string. Fixes #83

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,21 @@ Which will print:
 {'matched_paths': {"root['somewhere']": "around"},
  'matched_values': {"root['long']": "somewhere"}}
 ```
+Now, think of a case where you want to match a value as a word.
 
+```py
+from deepdiff import DeepSearch
+obj = {"long": "somewhere around", "string": 2, 0: 0, "somewhere": "around"}
+ds = DeepSearch(obj, "around", match_string=True, verbose_level=2)
+print(ds)
+ds = DeepSearch(obj, "around", verbose_level=2)
+print(ds)
+``` 
+Which will print:
+```py
+{'matched_values': {"root['somewhere']": 'around'}}
+{'matched_values': {"root['long']": 'somewhere around',"root['somewhere']": 'around'}}
+```
 Tip: An interesting use case is to search inside `locals()` when doing pdb.
 
 ## Grep

--- a/deepdiff/search.py
+++ b/deepdiff/search.py
@@ -78,6 +78,7 @@ class DeepSearch(dict):
                  exclude_types=set(),
                  verbose_level=1,
                  case_sensitive=False,
+                 match_string=False,
                  **kwargs):
         if kwargs:
             raise ValueError((
@@ -97,6 +98,9 @@ class DeepSearch(dict):
             matched_paths=self.__set_or_dict(),
             matched_values=self.__set_or_dict(),
             unprocessed=[])
+
+        # Cases where user wants to match exact string item
+        self.match_string = match_string
 
         self.__search(obj, item, parents_ids=frozenset({id(obj)}))
 
@@ -239,8 +243,14 @@ class DeepSearch(dict):
     def __search_str(self, obj, item, parent):
         """Compare strings"""
         obj_text = obj if self.case_sensitive else obj.lower()
-        if item in obj_text:
-            self.__report(report_key='matched_values', key=parent, value=obj)
+
+        if self.match_string:
+            if item == obj_text:
+                self.__report(report_key='matched_values', key=parent, value=obj) 
+
+        else:
+            if item in obj_text:
+                self.__report(report_key='matched_values', key=parent, value=obj)
 
     def __search_numbers(self, obj, item, parent):
         if item == obj:


### PR DESCRIPTION
Explanation for solving the issue:

```py
from deepdiff import DeepSearch
obj = {"long": "somewhere around", "string": 2, 0: 0, "somewhere": "around","empty":['','']}
# before fix
ds = DeepSearch(obj,'', verbose_level=2)
print "Before fix\n", ds
#after fix
ds = DeepSearch(obj,'', match_string=True,  verbose_level=2)
print "After fix\n", ds
```
Which willl print:
```py
Before fix
{'matched_paths': {"root['long']": 'somewhere around', 'root[0]': 0, "root['empty']": ['', ''], "root['somewhere']": 'around', "root['string']": 2}, 'matched_values': {"root['long']": 'somewhere around', "root['empty'][0]": '', "root['empty'][1]": '', "root['somewhere']": 'around'}}
After fix
{'matched_paths': {"root['long']": 'somewhere around', 'root[0]': 0, "root['empty']": ['', ''], "root['somewhere']": 'around', "root['string']": 2}, 'matched_values': {"root['empty'][0]": '', "root['empty'][1]": ''}}
```