### PR TITLE
Do not diff types when types are in strings

### DIFF
--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -1063,7 +1063,7 @@ class DeepDiff(ResultDict):
         if self.__skip_this(level):
             return
 
-        if type(level.t1) != type(level.t2):
+        if type(level.t1) != type(level.t2) and not isinstance(level.t1, strings) and not isinstance(level.t2, strings):
             self.__diff_types(level)
 
         elif isinstance(level.t1, strings):


### PR DESCRIPTION
Currently if the types are str and unicode, they "differ". In most cases it should make no difference, though, so I needed to ignore them (though there is probably a nicer solution for the problem than this one ;) ).