### PR TITLE
Design a workaround for unicode in py2

### DIFF
--- a/deepdiff/helper.py
+++ b/deepdiff/helper.py
@@ -113,3 +113,18 @@ class Verbose(object):
     Global verbose level
     """
     level = 1
+
+
+def gen_compatible_str(s):
+    """Generate compatible str for PY2.
+
+    The function convert unicode object to str with `repr`.
+    :param s: str/unicode in PY2, str in Py3.
+    """
+    if py3:
+        return s
+    else:
+        if isinstance(s, str):
+            return s
+        else:  # unicode
+            return repr(s)

--- a/deepdiff/model.py
+++ b/deepdiff/model.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from deepdiff.helper import items, RemapDict, strings, short_repr, Verbose, notpresent
+from deepdiff.helper import items, RemapDict, strings, short_repr, Verbose, notpresent, gen_compatible_str
 from ast import literal_eval
 from copy import copy
 
@@ -148,6 +148,7 @@ class TextResult(ResultDict):
                 )  # we want't the set's path, the removed item is not directly accessible
                 item = change.t1
                 if isinstance(item, strings):
+                    item = gen_compatible_str(item)
                     item = "'%s'" % item
                 self['set_item_removed'].add("%s[%s]" % (path, str(item)))
                 # this syntax is rather peculiar, but it's DeepDiff 2.x compatible
@@ -159,6 +160,7 @@ class TextResult(ResultDict):
                 )  # we want't the set's path, the added item is not directly accessible
                 item = change.t2
                 if isinstance(item, strings):
+                    item = gen_compatible_str(item)
                     item = "'%s'" % item
                 self['set_item_added'].add("%s[%s]" % (path, str(item)))
                 # this syntax is rather peculiar, but it's DeepDiff 2.x compatible)
@@ -582,6 +584,7 @@ class ChildRelationship(object):
         """
         param = self.param
         if isinstance(param, strings):
+            param = gen_compatible_str(param)
             result = param if self.quote_str is None else self.quote_str.format(param)
         else:
             candidate = str(param)
@@ -595,6 +598,7 @@ class ChildRelationship(object):
                 result = candidate if resurrected == param else None
 
         if result:
+            result = gen_compatible_str(result)
             result = ':' if self.param_repr_format is None else self.param_repr_format.format(result)
 
         return result

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -239,6 +239,43 @@ class DeepDiffTextTestCase(unittest.TestCase):
         }
         self.assertEqual(ddiff, result)
 
+    def test_dict_with_unicode_key(self):
+        t1 = {u'中文': 2}
+        t2 = {u'中文': 3}
+        ddiff = DeepDiff(t1, t2)
+        if py3:
+            result = {
+                'values_changed': {
+                    "root['中文']": {
+                        'new_value': 3,
+                        'old_value': 2
+                    }
+                }
+            }
+        else:
+            result = {
+                'values_changed': {
+                    "root['u'\\u4e2d\\u6587'']": {
+                        'new_value': 3,
+                        'old_value': 2
+                    }
+                }
+            }
+        self.assertEqual(ddiff, result)
+
+    def test_set_with_unicode(self):
+        t1 = set((u'中文',))
+        t2 = set(('中文',))
+        ddiff = DeepDiff(t1, t2)
+        if py3:
+            result = {}
+        else:
+            result = {
+                'set_item_added': set(["root['\xe4\xb8\xad\xe6\x96\x87']"]),
+                'set_item_removed': set(["root['u'\\u4e2d\\u6587'']"])
+            }
+        self.assertEqual(ddiff, result)
+
     def test_type_change(self):
         t1 = {1: 1, 2: 2, 3: 3, 4: {"a": "hello", "b": [1, 2, 3]}}
         t2 = {1: 1, 2: 2, 3: 3, 4: {"a": "hello", "b": "world\n\n\nEnd"}}


### PR DESCRIPTION
Hi, I'm a Python2.7 user. I struggled with the unicode type when I used deepdiff.
The problem may be like this:
```python
t1 = {u'中文': 2}
t2 = {u'中文': 3}
ddiff = DeepDiff(t1, t2)
```
The codes above didn't work with raising expceptions about encoding.So I put forward this pr to solve this problem. The pr aims to make it work well when there are some py2 unicode strings in dict keys.And the pr won't affect the behavior of the software in py3. 
Thanks!