### PR TITLE
Exclude types when ignoring order

### DIFF
--- a/deepdiff/contenthash.py
+++ b/deepdiff/contenthash.py
@@ -233,6 +233,8 @@ class DeepHash(dict):
         obj_keys = set(obj.keys())
 
         for key in obj_keys:
+            if self.__skip_this(obj[key]):
+                continue
             key_hash = self.__hash(key)
             item = obj[key]
             item_id = id(item)

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -197,8 +197,8 @@ class DeepDiff(ResultDict):
 
         >>>
         >>> print (ddiff['values_changed']["root[4]['b']"]["diff"])
-        --- 
-        +++ 
+        ---
+        +++
         @@ -1,5 +1,4 @@
         -world!
         -Goodbye!
@@ -992,6 +992,7 @@ class DeepDiff(ResultDict):
             try:
                 hashes_all = DeepHash(item,
                                       hashes=self.hashes,
+                                      exclude_types=self.exclude_types,
                                       significant_digits=self.significant_digits,
                                       include_string_type_changes=self.include_string_type_changes)
                 item_hash = hashes_all.get(id(item), item)

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -1397,6 +1397,20 @@ class DeepDiffTextTestCase(unittest.TestCase):
         result = {}
         self.assertEqual(ddiff, result)
 
+    def test_skip_str_type_in_dict_on_list(self):
+        t1 = [{1: "a"}]
+        t2 = [{}]
+        ddiff = DeepDiff(t1, t2, exclude_types=[str])
+        result = {}
+        self.assertEqual(ddiff, result)
+
+    def test_skip_str_type_in_dict_on_list_when_ignored_order(self):
+        t1 = [{1: "a"}]
+        t2 = [{}]
+        ddiff = DeepDiff(t1, t2, exclude_types=[str], ignore_order=True)
+        result = {}
+        self.assertEqual(ddiff, result)
+
     def test_unknown_parameters(self):
         with self.assertRaises(ValueError):
             DeepDiff(1, 1, wrong_param=2)


### PR DESCRIPTION
As the included new test says `DeepDiff` wrongfully reported a difference for excluded type when the option `ignore_order=True` was set. This fails without the fix:

```
        t1 = [{1: "a"}]
        t2 = [{}]
        ddiff = DeepDiff(t1, t2, exclude_types=[str], ignore_order=True)
        result = {}
        self.assertEqual(ddiff, result)
```