### PR TITLE
basic sketch of eq_types

### DIFF
--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -657,6 +657,7 @@ class DeepDiff(ResultDict):
                  exclude_regex_paths=set(),
                  exclude_types=set(),
                  include_string_type_changes=False,
+                 eq_types = set(),
                  verbose_level=1,
                  view='text',
                  **kwargs):
@@ -673,7 +674,9 @@ class DeepDiff(ResultDict):
         self.exclude_types = set(exclude_types)
         self.exclude_types_tuple = tuple(exclude_types)  # we need tuple for checking isinstance
         self.include_string_type_changes = include_string_type_changes
+        self.eq_types = set(eq_types)
         self.hashes = {}
+
 
         if significant_digits is not None and significant_digits < 0:
             raise ValueError(
@@ -758,6 +761,14 @@ class DeepDiff(ResultDict):
     def __diff_obj(self, level, parents_ids=frozenset({}),
                    is_namedtuple=False):
         """Difference of 2 objects"""
+
+        if type(level.t1) in self.eq_types:
+            if level.t1 == level.t2:
+                return
+            else:
+                self.__report_result('values_changed', level)
+                return
+
         try:
             if is_namedtuple:
                 t1 = level.t1._asdict()


### PR DESCRIPTION
per issue #103 

I'm completely ignoring how DeepDiff *should* handle the issue/corner case.

I'm suggesting a basic sketch of how this might work within deepdiff in the PR. 

The basic strategy is take a container/dict called `eq_types` as an argument (just like exclude_types) to DeepDiff. When`__diff_obj()` is called, the first thing it would do is check if the type of `level.t1` is in `eq_types`, then it would invoke `__eq__` to compare the objects. (God, python is so readable, I feel like none of this is necessary to explain). Otherwise, the object is treated as before. 

Here is some trivial example code: 

```
# ######################################################
# Install this jmccreight/dev PR.
import pathlib
from deepdiff import DeepDiff

# Great... 
p1='foobar'
p2='barfoo'
assert p1 != p2
assert not p1.__eq__(p2)
assert bool(DeepDiff(p1, p2)) is True # True == not-empty

# Huh?...
pp1=pathlib.PosixPath(p1)
pp2=pathlib.PosixPath(p2)
assert pp1 != pp2
assert not pp1.__eq__(pp2)

assert bool(DeepDiff(pp1, pp2)) is True # True == not-empty

assert bool(DeepDiff(pp1, pp2, eq_types={pathlib.PosixPath})) is True # True == not-empty
DeepDiff(pp1, pp2, eq_types={pathlib.PosixPath})
```

I also came up with the solution if I want to subclass DeepDiff and not rely on this functionality being added, FWIW: 

```
# ######################################################
# Subclass instead of PR - dont depend on distribution of deepdiff.
# Install the upstream/master.
import pathlib
from deepdiff import DeepDiff

class DeepDiffEq(DeepDiff):
    def __init__(self,
                 t1,
                 t2,
                 eq_types,
                 ignore_order=False,
                 report_repetition=False,
                 significant_digits=None,
                 exclude_paths=set(),
                 exclude_regex_paths=set(),
                 exclude_types=set(),
                 include_string_type_changes=False,
                 verbose_level=1,
                 view='text',
                 **kwargs):

        # Must set this first for some reason.
        self.eq_types = set(eq_types)
        super().__init__(t1,
                         t2,
                         ignore_order=False,
                         report_repetition=False,
                         significant_digits=None,
                         exclude_paths=set(),
                         exclude_regex_paths=set(),
                         exclude_types=set(),
                         include_string_type_changes=False,
                         verbose_level=1,
                         view='text',
                         **kwargs)

    # Have to force override __diff_obj.
    def _DeepDiff__diff_obj(self, level, parents_ids=frozenset({}),
                            is_namedtuple=False):
        """Difference of 2 objects using their __eq__ if requested"""
        if type(level.t1) in self.eq_types:
            if level.t1 == level.t2:
                return
            else:
                self._DeepDiff__report_result('values_changed', level)
                return
        super(DeepDiffEq, self)._DeepDiff__diff_obj(level, parents_ids=frozenset({}),
                                                    is_namedtuple=False)

p1='foobar'
p2='barfoo'
pp1=pathlib.PosixPath(p1)
pp2=pathlib.PosixPath(p2)
DeepDiffEq(pp1, pp2, eq_types={pathlib.PosixPath})
DeepDiffEq(pp1, pp2, eq_types={DeepDiff})
```