### PR TITLE
add tests to make sure hashing and comparing enums works

### DIFF
--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -761,6 +761,32 @@ class TestDeepDiffText:
         }
         assert result == ddiff
 
+    def test_enums(self):
+        from enum import Enum
+
+        class MyEnum(Enum):
+            A = 1
+            B = 2
+
+        ddiff = DeepDiff(MyEnum.A, MyEnum(1))
+        result = {}
+        assert ddiff == result
+
+        ddiff = DeepDiff(MyEnum.A, MyEnum.B)
+        result = {
+            'values_changed': {
+                'root._name_': {
+                    'old_value': 'A',
+                    'new_value': 'B'
+                },
+                'root._value_': {
+                    'old_value': 1,
+                    'new_value': 2
+                }
+            }
+        }
+        assert ddiff == result
+
     def test_custom_objects_change(self):
         t1 = CustomClass(1)
         t2 = CustomClass(2)

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -7,6 +7,7 @@ from deepdiff.helper import pypy3
 from collections import namedtuple
 from functools import partial
 import logging
+from enum import Enum
 
 logging.disable(logging.CRITICAL)
 
@@ -94,7 +95,7 @@ class TestDeepHashPrep:
 
     def test_named_tuples(self):
         # checking if pypy3 is running the test
-        # in that case due to a pypy3 bug or something
+        # in that case due to a difference of string interning implementation
         # the id of x inside the named tuple changes.
         x = "x"
         x_id = id(x)
@@ -111,6 +112,38 @@ class TestDeepHashPrep:
                 id(11): 'int:11',
             }
             assert expected_result == result
+
+    def test_enum(self):
+        class MyEnum(Enum):
+            A = 1
+            B = 2
+
+        # checking if pypy3 is running the test
+        # in that case due to a difference of string interning implementation
+        # the ids of strings change
+        if pypy3:
+            # only compare the hashes for the enum instances themselves
+            assert DeepHashPrep(MyEnum.A)[id(MyEnum.A)] == (
+                'objdict:{'
+                '__objclass__:EnumMeta:objdict:{_name_:B;_value_:int:2};'
+                '_name_:A;_value_:int:1}'
+            )
+            assert DeepHashPrep(MyEnum.B)[id(MyEnum.B)] == (
+                'objdict:{'
+                '__objclass__:EnumMeta:objdict:{_name_:A;_value_:int:1};'
+                '_name_:B;_value_:int:2}'
+            )
+            assert DeepHashPrep(MyEnum(1))[id(MyEnum.A)] == (
+                'objdict:{'
+                '__objclass__:EnumMeta:objdict:{_name_:B;_value_:int:2};'
+                '_name_:A;_value_:int:1}'
+            )
+        else:
+            assert DeepHashPrep(MyEnum.A) == DeepHashPrep(MyEnum.A)
+            assert DeepHashPrep(MyEnum.A) == DeepHashPrep(MyEnum(1))
+            assert DeepHashPrep(MyEnum.A) != DeepHashPrep(MyEnum.A.name)
+            assert DeepHashPrep(MyEnum.A) != DeepHashPrep(MyEnum.A.value)
+            assert DeepHashPrep(MyEnum.A) != DeepHashPrep(MyEnum.B)
 
     def test_dict_hash(self):
         string1 = "a"


### PR DESCRIPTION
Turns out the problem with comparing Enums was actually a bug in the loop detection in master, which is already fixed in the dev branch. The `__hash` function received an (unused) second parameter `parent` which was receiving the value intended for the third `parents_ids` parameter.

I added a couple tests anyway just to make sure it works as expected and to prevent regression.

In the hash test, I didn't really know how to go about manually building the `expected_result`, so I compared hashes to each other instead. Let me know if that's ok.

Fixes #114 