### PR TITLE
fix comparison of objects with __weakref__ in __slots__

### DIFF
--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -743,7 +743,7 @@ class DeepDiff(ResultDict):
     @staticmethod
     def __dict_from_slots(object):
         def unmangle(attribute):
-            if attribute.startswith('__'):
+            if attribute.startswith('__') and attribute != '__weakref__':
                 return '_{type}{attribute}'.format(
                     type=type(object).__name__,
                     attribute=attribute

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -836,6 +836,26 @@ class DeepDiffTextTestCase(unittest.TestCase):
         diff = DeepDiff(t1, t2)
         self.assertEqual(diff, {})
 
+    def test_custom_objects_with_weakref_in_slots(self):
+        class ClassA(object):
+            __slots__ = ['a', '__weakref__']
+
+            def __init__(self, a):
+                self.a = a
+
+        t1 = ClassA(1)
+        t2 = ClassA(2)
+        diff = DeepDiff(t1, t2)
+        result = {
+            'values_changed': {
+                'root.a': {
+                    'new_value': 2,
+                    'old_value': 1
+                }
+            },
+        }
+        self.assertEqual(diff, result)
+
     def get_custom_objects_add_and_remove(self):
         class ClassA(object):
             a = 1


### PR DESCRIPTION
Prevents attempted unmangling of the __weakref__ attribute if present in a __slots__.

Note that a __dict__ inside a __slots__ is still unsupported, and is a little more complicated to solve.

Fixes #115 