### PR TITLE
Declare dependency on Python version. Fixes #130.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(name='deepdiff',
       long_description=long_description,
       long_description_content_type='text/markdown',
       install_requires=reqs,
+      python_requires='>=3.4',
       classifiers=[
           "Intended Audience :: Developers",
           "Operating System :: OS Independent",


### PR DESCRIPTION
As requested, this commit adds the `python_requires` declaration, signaling to installers not to install this code on older Pythons. Ideally, this will be released as a bugfix release to the 4.0.0 release and 4.0.0 pulled from PyPI (to avoid downstream projects having to blacklist it to prevent installation on older Pythons).