### PR TITLE
Include license and tests in sdist archive

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 include *.rst
 include deepdiff/*.rst
 include *.txt
+include LICENSE AUTHORS
+recursive-include tests *.py
 global-exclude __pycache__
 global-exclude *.py[co]


### PR DESCRIPTION
This archive is used by distributions and license should be always shipped with the source code.