### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,11 @@ language: python
 
 matrix:
   include:
-    - python: 3.4
     - python: 3.5
     - python: 3.6
     - python: pypy3
     - python: 3.7
     - python: 3.8
-      dist: xenial
-      sudo: true
 
 install:
   - pip install -r requirements-dev.txt

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - DeepSearch: Search for objects within other objects.
 - DeepHash: Hash any object based on their content.
 
-Tested on Python 3.4, 3.5, 3.6, 3.7, Pypy3
+Tested on Python 3.5+ and PyPy3.
 
 **NOTE: Python 2 is not supported any more. DeepDiff v3.3.0 was the last version to support Python 2**
 

--- a/deepdiff/deephash.py
+++ b/deepdiff/deephash.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import logging
 from collections.abc import Iterable, MutableMapping
 from collections import defaultdict
@@ -232,7 +231,7 @@ class DeepHash(dict, Base):
                     break
         else:
             type_str = 'dict'
-        return "%s:{%s}" % (type_str, result)
+        return "{}:{{{}}}".format(type_str, result)
 
     def _prep_iterable(self, obj, parent, parents_ids=EMPTY_FROZENSET):
 

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 # In order to run the docstrings:
 # python3 -m deepdiff.diff

--- a/deepdiff/helper.py
+++ b/deepdiff/helper.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import sys
 import datetime
 import re
@@ -166,7 +165,7 @@ def add_to_frozen_set(parents_ids, item_id):
 def convert_item_or_items_into_set_else_none(items):
     if items:
         if isinstance(items, strings):
-            items = set([items])
+            items = {items}
         else:
             items = set(items)
     else:

--- a/deepdiff/model.py
+++ b/deepdiff/model.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from deepdiff.helper import RemapDict, strings, short_repr, Verbose, notpresent
 from ast import literal_eval
 from copy import copy
@@ -156,7 +154,7 @@ class TextResult(ResultDict):
     def _from_tree_unprocessed(self, tree):
         if 'unprocessed' in tree:
             for change in tree['unprocessed']:
-                self['unprocessed'].append("%s: %s and %s" % (change.path(
+                self['unprocessed'].append("{}: {} and {}".format(change.path(
                     force=FORCE_DEFAULT), change.t1, change.t2))
 
     def _from_tree_set_item_removed(self, tree):
@@ -167,7 +165,7 @@ class TextResult(ResultDict):
                 item = change.t1
                 if isinstance(item, strings):
                     item = "'%s'" % item
-                self['set_item_removed'].add("%s[%s]" % (path, str(item)))
+                self['set_item_removed'].add("{}[{}]".format(path, str(item)))
                 # this syntax is rather peculiar, but it's DeepDiff 2.x compatible
 
     def _from_tree_set_item_added(self, tree):
@@ -178,7 +176,7 @@ class TextResult(ResultDict):
                 item = change.t2
                 if isinstance(item, strings):
                     item = "'%s'" % item
-                self['set_item_added'].add("%s[%s]" % (path, str(item)))
+                self['set_item_added'].add("{}[{}]".format(path, str(item)))
                 # this syntax is rather peculiar, but it's DeepDiff 2.x compatible)
 
     def _from_tree_repetition_change(self, tree):
@@ -190,7 +188,7 @@ class TextResult(ResultDict):
                 self['repetition_change'][path]['value'] = change.t1
 
 
-class DiffLevel(object):
+class DiffLevel:
     """
     An object of this class represents a single object-tree-level in a reported change.
     A double-linked list of these object describes a single change on all of its levels.
@@ -523,7 +521,7 @@ class DiffLevel(object):
         return result
 
 
-class ChildRelationship(object):
+class ChildRelationship:
     """
     Describes the relationship between a container object (the "parent") and the contained
     "child" object.

--- a/deepdiff/search.py
+++ b/deepdiff/search.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import re
 from collections.abc import MutableMapping, Iterable
 import logging
@@ -225,7 +224,7 @@ class DeepSearch(dict):
         """Search iterables except dictionaries, sets and strings."""
 
         for i, thing in enumerate(obj):
-            new_parent = "%s[%s]" % (parent, i)
+            new_parent = "{}[{}]".format(parent, i)
             if self.__skip_this(thing, parent=new_parent):
                 continue
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # DeepDiff documentation build configuration file, created by
 # sphinx-quickstart on Mon Jul 20 06:06:44 2015.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
-
-class CustomClass(object):
+class CustomClass:
     def __init__(self, a, b=None):
         self.a = a
         self.b = b

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import datetime
 import pytest
 import logging
@@ -271,19 +270,19 @@ class TestDeepDiffText:
             2: 2,
             3: 3,
             4: {
-                "a": u"hello",
-                "b": u"world!\nGoodbye!\n1\n2\nEnd"
+                "a": "hello",
+                "b": "world!\nGoodbye!\n1\n2\nEnd"
             }
         }
-        t2 = {1: 1, 2: 2, 3: 3, 4: {"a": u"hello", "b": u"world\n1\n2\nEnd"}}
+        t2 = {1: 1, 2: 2, 3: 3, 4: {"a": "hello", "b": "world\n1\n2\nEnd"}}
         ddiff = DeepDiff(t1, t2)
         result = {
             'values_changed': {
                 "root[4]['b']": {
                     'diff':
                     '--- \n+++ \n@@ -1,5 +1,4 @@\n-world!\n-Goodbye!\n+world\n 1\n 2\n End',
-                    'new_value': u'world\n1\n2\nEnd',
-                    'old_value': u'world!\nGoodbye!\n1\n2\nEnd'
+                    'new_value': 'world\n1\n2\nEnd',
+                    'old_value': 'world!\nGoodbye!\n1\n2\nEnd'
                 }
             }
         }
@@ -597,7 +596,7 @@ class TestDeepDiffText:
         """
         https://github.com/seperman/deepdiff/issues/64
         """
-        ddiff = DeepDiff(set(), set([None]))
+        ddiff = DeepDiff(set(), {None})
         assert {'set_item_added': {'root[None]'}} == ddiff
 
     def test_list_that_contains_dictionary(self):
@@ -971,7 +970,7 @@ class TestDeepDiffText:
         assert result == ddiff
 
     def test_custom_objects_with_single_protected_slot(self):
-        class ClassA(object):
+        class ClassA:
             __slots__ = '__a'
 
             def __init__(self):
@@ -986,7 +985,7 @@ class TestDeepDiffText:
         assert {} == ddiff
 
     def test_custom_objects_with_weakref_in_slots(self):
-        class ClassA(object):
+        class ClassA:
             __slots__ = ['a', '__weakref__']
 
             def __init__(self, a):
@@ -1006,7 +1005,7 @@ class TestDeepDiffText:
         assert result == diff
 
     def get_custom_objects_add_and_remove(self):
-        class ClassA(object):
+        class ClassA:
             a = 1
 
             def __init__(self, b):
@@ -1054,7 +1053,7 @@ class TestDeepDiffText:
         assert result == ddiff
 
     def get_custom_object_with_added_removed_methods(self):
-        class ClassA(object):
+        class ClassA:
             def method_a(self):
                 pass
 
@@ -1128,7 +1127,7 @@ class TestDeepDiffText:
         assert not DeepDiff(burritos, tacos, ignore_type_in_groups=[(Taco, Burrito)], ignore_order=True)
 
     def test_loop(self):
-        class LoopTest(object):
+        class LoopTest:
             def __init__(self, a):
                 self.loop = self
                 self.a = a
@@ -1148,12 +1147,12 @@ class TestDeepDiffText:
         assert result == ddiff
 
     def test_loop2(self):
-        class LoopTestA(object):
+        class LoopTestA:
             def __init__(self, a):
                 self.loop = LoopTestB
                 self.a = a
 
-        class LoopTestB(object):
+        class LoopTestB:
             def __init__(self, a):
                 self.loop = LoopTestA
                 self.a = a
@@ -1173,7 +1172,7 @@ class TestDeepDiffText:
         assert result == ddiff
 
     def test_loop3(self):
-        class LoopTest(object):
+        class LoopTest:
             def __init__(self, a):
                 self.loop = LoopTest
                 self.a = a
@@ -1254,15 +1253,15 @@ class TestDeepDiffText:
         Writing b"你好" throws an exception in Python 3 so can't be used for testing.
         These tests are currently useless till they are rewritten properly.
         """
-        unicode_string = {"hello": u"你好"}
+        unicode_string = {"hello": "你好"}
         ascii_string = {"hello": "你好"}
         ddiff = DeepDiff(unicode_string, ascii_string)
         result = {}
         assert result == ddiff
 
     def test_unicode_string_value_changes(self):
-        unicode_string = {"hello": u"你好"}
-        ascii_string = {"hello": u"你好hello"}
+        unicode_string = {"hello": "你好"}
+        ascii_string = {"hello": "你好hello"}
         ddiff = DeepDiff(unicode_string, ascii_string)
         result = {
             'values_changed': {
@@ -1275,7 +1274,7 @@ class TestDeepDiffText:
         assert result == ddiff
 
     def test_unicode_string_value_and_type_changes(self):
-        unicode_string = {"hello": u"你好"}
+        unicode_string = {"hello": "你好"}
         ascii_string = {"hello": "你好hello"}
         ddiff = DeepDiff(unicode_string, ascii_string)
         # In python3, all string is unicode, so these 2 strings only diff
@@ -1310,7 +1309,7 @@ class TestDeepDiffText:
 
     def test_int_to_unicode(self):
         t1 = 1
-        unicode_string = u"你好"
+        unicode_string = "你好"
         ddiff = DeepDiff(t1, unicode_string)
         # In python3, all string is unicode, so these 2 strings only diff
         # in values

--- a/tests/test_diff_tree.py
+++ b/tests/test_diff_tree.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import pytest
 from deepdiff import DeepDiff
 from deepdiff.helper import pypy3, notpresent

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import re
 import pytest
 import logging
@@ -235,7 +234,7 @@ class TestDeepHashPrep:
             20: 'int:20',
             key1: key1_prepped,
             string1: string1_prepped,
-            get_id(obj): 'dict:{int:1:int:10;int:2:int:20;%s:%s}' % (key1, string1)
+            get_id(obj): 'dict:{{int:1:int:10;int:2:int:20;{}:{}}}'.format(key1, string1)
         }
         result = DeepHashPrep(obj, ignore_string_type_changes=True)
         assert expected_result == result

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import pytest
 from decimal import Decimal
 from deepdiff.helper import short_repr, number_to_string

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import logging
 import pytest
 from tests import CustomClass, CustomClassMisleadingRepr

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import pytest
 from deepdiff import DeepSearch, grep
 from datetime import datetime
@@ -177,7 +176,7 @@ class TestDeepSearch:
         assert list(ds["matched_values"].values())[0] == item
 
     def test_loop(self):
-        class LoopTest(object):
+        class LoopTest:
             def __init__(self, a):
                 self.loop = self
                 self.a = a
@@ -245,7 +244,7 @@ class TestDeepSearch:
             DeepSearch(1, 1, wrong_param=2)
 
     def test_bad_attribute(self):
-        class Bad(object):
+        class Bad:
             __slots__ = ['x', 'y']
 
             def __getattr__(self, key):
@@ -314,7 +313,7 @@ class TestDeepSearch:
         assert DeepSearch(obj, item, verbose_level=1) == result
 
     def test_search_inherited_attributes(self):
-        class Parent(object):
+        class Parent:
             a = 1
 
         class Child(Parent):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import json
 import pytest
 from deepdiff import DeepDiff


### PR DESCRIPTION
Python 3.4 is EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.7 | 2010-07-03 | 2020-01-01
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history

It's also little used. Here's the pip installs for deepdiff from PyPI for December 2019:

| category | percent | downloads |
|----------|--------:|----------:|
| 2.7      |  65.98% |   762,527 |
| 3.6      |  17.69% |   204,486 |
| 3.7      |   9.98% |   115,302 |
| 3.5      |   5.10% |    58,941 |
| 3.8      |   0.88% |    10,196 |
| null     |   0.25% |     2,920 |
| 3.4      |   0.12% |     1,341 |
| 2.6      |   0.00% |         5 |
| 3.9      |   0.00% |         3 |
| 3.3      |   0.00% |         1 |
| Total    |         | 1,155,722 |

Date range: 2019-12-01 - 2019-12-31

Source: `pip install -U pypistats && pypistats python_minor deepdiff --last-month`

This PR also upgrades Python syntax with https://github.com/asottile/pyupgrade/, caches pip on the CI to speed up builds, and removes some CI config for Python 3.8 which is no longer needed.
