### PR TITLE
flexible ignorance

### DIFF
--- a/deepdiff/deephash.py
+++ b/deepdiff/deephash.py
@@ -69,6 +69,7 @@ class DeepHash(dict, Base):
                  ignore_numeric_type_changes=False,
                  ignore_type_subclasses=False,
                  ignore_string_case=False,
+                 exclude_obj_callback=None,
                  number_to_string_func=None,
                  **kwargs):
         if kwargs:
@@ -101,6 +102,7 @@ class DeepHash(dict, Base):
         self.ignore_string_type_changes = ignore_string_type_changes
         self.ignore_numeric_type_changes = ignore_numeric_type_changes
         self.ignore_string_case = ignore_string_case
+        self.exclude_obj_callback = exclude_obj_callback
         # makes the hash return constant size result if true
         # the only time it should be set to False is when
         # testing the individual hash functions for different types of objects.
@@ -197,9 +199,10 @@ class DeepHash(dict, Base):
         elif self.exclude_regex_paths and any(
                 [exclude_regex_path.search(parent) for exclude_regex_path in self.exclude_regex_paths]):
             skip = True
-        else:
-            if self.exclude_types_tuple and isinstance(obj, self.exclude_types_tuple):
-                skip = True
+        elif self.exclude_types_tuple and isinstance(obj, self.exclude_types_tuple):
+            skip = True
+        elif self.exclude_obj_callback and self.exclude_obj_callback(obj, parent):
+            skip = True
 
         return skip
 

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -58,6 +58,7 @@ class DeepDiff(ResultDict, Base):
                  ignore_numeric_type_changes=False,
                  ignore_type_subclasses=False,
                  ignore_string_case=False,
+                 exclude_obj_callback=None,
                  number_to_string_func=None,
                  ignore_nan_inequality=False,
                  verbose_level=1,
@@ -88,6 +89,7 @@ class DeepDiff(ResultDict, Base):
         self.ignore_type_subclasses = ignore_type_subclasses
         self.type_check_func = type_is_subclass_of_type_group if ignore_type_subclasses else type_in_type_group
         self.ignore_string_case = ignore_string_case
+        self.exclude_obj_callback = exclude_obj_callback
         self.number_to_string = number_to_string_func or number_to_string
         self.ignore_nan_inequality = ignore_nan_inequality
         self.hashes = {}
@@ -219,10 +221,12 @@ class DeepDiff(ResultDict, Base):
         elif self.exclude_regex_paths and any(
                 [exclude_regex_path.search(level.path()) for exclude_regex_path in self.exclude_regex_paths]):
             skip = True
-        else:
-            if self.exclude_types_tuple and (isinstance(level.t1, self.exclude_types_tuple) or
-                                             isinstance(level.t2, self.exclude_types_tuple)):
-                skip = True
+        elif self.exclude_types_tuple and \
+                (isinstance(level.t1, self.exclude_types_tuple) or isinstance(level.t2, self.exclude_types_tuple)):
+            skip = True
+        elif self.exclude_obj_callback and \
+                (self.exclude_obj_callback(level.t1, level.path()) or self.exclude_obj_callback(level.t2, level.path())):
+            skip = True
 
         return skip
 

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -1628,6 +1628,16 @@ class TestDeepDiffText:
         result = {}
         assert result == ddiff
 
+    def test_skip_exclude_obj_callback(self):
+        def exclude_obj_callback(obj, path):
+            return True if "skip" in path or isinstance(obj, int) else False
+
+        t1 = {"x": "a", "y": "b", "z": "c", "skip_1": 0}
+        t2 = {"x": "a", "y": "b", "z": "c", "skip_2": 1}
+        ddiff = DeepDiff(t1, t2, exclude_obj_callback=exclude_obj_callback)
+        result = {}
+        assert result == ddiff
+
     def test_skip_str_type_in_dictionary(self):
         t1 = {1: {2: "a"}}
         t2 = {1: {}}

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -529,6 +529,16 @@ class TestDeepHashPrep:
         assert 2 in t1_hash
         assert t1_hash[2] == t2_hash[2]
 
+    def test_skip_exclude_obj_callback(self):
+        def exclude_obj_callback(obj, parent):
+            return True if parent == "root['x']" or obj == 2 else False
+
+        dic1 = {"x": 1, "y": 2, "z": 3}
+        t1 = [dic1]
+        t1_hash = DeepHashPrep(t1, exclude_obj_callback=exclude_obj_callback)
+        assert t1_hash == {'y': 'str:y', 'z': 'str:z', 3: 'int:3',
+                           get_id(dic1): 'dict:{str:z:int:3}', get_id(t1): 'list:dict:{str:z:int:3}'}
+
     def test_string_case(self):
         t1 = "Hello"
 


### PR DESCRIPTION
It may difficult to create ignorance rules using regular expressions and other parameters.

....exclude_types=EXCLUDED_TYPES, ignore_type_subclasses=True, exclude_regex_paths={r".*mock.*", r".*deepdiff.*", r"._.*"})...

Maybe a flexible callback is useful
def ignore_obj_callback(obj, parent):
    return False