### PR TITLE
Pretty form

### DIFF
--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -722,7 +722,22 @@ class DeepDiff(ResultDict, Base):
         return result
 
     def pretty_form(self):
-        pass
+        result = []
+        for key in self.tree.keys():
+            for item_key in self.tree[key]:
+                result += [pretty_print_diff(item_key)]
+
+        return '\n'.join(result)
+
+
+def pretty_print_diff(diff: DiffLevel):
+    if diff.report_type == "type_changes":
+        return f'Type of {diff.path(root="")} changed from {type(diff.t1).__name__} to {type(diff.t2).__name__}' \
+               f' and value changed from {str(diff.t1)} to {str(diff.t2)}'
+    elif diff.report_type == "values_changed":
+        return f'Value of {diff.path(root="")} changed from {str(diff.t1)} to {str(diff.t2)}'
+    else:
+        return ''
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -738,7 +738,7 @@ def pretty_print_diff(diff: DiffLevel):
     val_t1 = f'"{str(diff.t1)}"' if type_t1 == "str" else str(diff.t1)
     val_t2 = f'"{str(diff.t2)}"' if type_t2 == "str" else str(diff.t2)
 
-    diff_path = diff.path(root='root') if diff.report_type in ['attribute_added', 'attribute_removed'] else diff.path(root='')
+    diff_path = diff.path(root='root')
 
     texts = {
         "type_changes": "Type of {diff_path} changed from {type_t1} to {type_t2} and value changed from {val_t1} to {val_t2}",
@@ -749,8 +749,8 @@ def pretty_print_diff(diff: DiffLevel):
         "iterable_item_removed": "Item {diff_path} removed from iterable.",
         "attribute_added": "Attribute {diff_path} added.",
         "attribute_removed": "Attribute {diff_path} removed.",
-        "set_item_added": "Item [{val_t2}] added to set.",
-        "set_item_removed": "Item [{val_t1}] removed from set.",
+        "set_item_added": "Item root[{val_t2}] added to set.",
+        "set_item_removed": "Item root[{val_t1}] removed from set.",
         "repetition_change": "Repetition change for item {diff_path}.",
              }
 

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -749,6 +749,12 @@ def pretty_print_diff(diff: DiffLevel):
         return f'Attribute {diff.path(root="root")} added.'
     elif diff.report_type == "attribute_removed":
         return f'Attribute {diff.path(root="root")} removed.'
+    elif diff.report_type == "set_item_added":
+        return f'Item [{str(diff.t2)}] added to set.'
+    elif diff.report_type == "set_item_removed":
+        return f'Item [{str(diff.t1)}] removed from set.'
+    elif diff.report_type == "repetition_change":
+        return f'Repetition change for item {diff.path(root="")}.'
     else:
         return ''
 

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -721,6 +721,9 @@ class DeepDiff(ResultDict, Base):
             result = dict(self)
         return result
 
+    def pretty_form(self):
+        pass
+
 
 if __name__ == "__main__":  # pragma: no cover
     import doctest

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -735,41 +735,27 @@ def pretty_print_diff(diff: DiffLevel):
     type_t1 = get_type(diff.t1).__name__
     type_t2 = get_type(diff.t2).__name__
 
-    if type_t1 == "str":
-        val_t1 = f'"{str(diff.t1)}"'
-    else:
-        val_t1 = str(diff.t1)
+    val_t1 = f'"{str(diff.t1)}"' if type_t1 == "str" else str(diff.t1)
+    val_t2 = f'"{str(diff.t2)}"' if type_t2 == "str" else str(diff.t2)
 
-    if type_t2 == "str":
-        val_t2 = f'"{str(diff.t2)}"'
-    else:
-        val_t2 = str(diff.t2)
+    diff_path = diff.path(root='root') if diff.report_type in ['attribute_added', 'attribute_removed'] else diff.path(root='')
 
-    if diff.report_type == "type_changes":
-        return f'Type of {diff.path(root="")} changed from {type_t1} to {type_t2}' \
-               f' and value changed from {val_t1} to {val_t2}'
-    elif diff.report_type == "values_changed":
-        return f'Value of {diff.path(root="")} changed from {val_t1} to {val_t2}'
-    elif diff.report_type == "dictionary_item_added":
-        return f'Item {diff.path(root="")} added to dictionary.'
-    elif diff.report_type == "dictionary_item_removed":
-        return f'Item {diff.path(root="")} removed from dictionary.'
-    elif diff.report_type == "iterable_item_added":
-        return f'Item {diff.path(root="")} added to iterable.'
-    elif diff.report_type == "iterable_item_removed":
-        return f'Item {diff.path(root="")} removed from iterable.'
-    elif diff.report_type == "attribute_added":
-        return f'Attribute {diff.path(root="root")} added.'
-    elif diff.report_type == "attribute_removed":
-        return f'Attribute {diff.path(root="root")} removed.'
-    elif diff.report_type == "set_item_added":
-        return f'Item [{val_t2}] added to set.'
-    elif diff.report_type == "set_item_removed":
-        return f'Item [{val_t1}] removed from set.'
-    elif diff.report_type == "repetition_change":
-        return f'Repetition change for item {diff.path(root="")}.'
-    else:
-        return ''
+    texts = {
+        "type_changes": "Type of {diff_path} changed from {type_t1} to {type_t2} and value changed from {val_t1} to {val_t2}",
+        "values_changed": "Value of {diff_path} changed from {val_t1} to {val_t2}",
+        "dictionary_item_added": "Item {diff_path} added to dictionary.",
+        "dictionary_item_removed": "Item {diff_path} removed from dictionary.",
+        "iterable_item_added": "Item {diff_path} added to iterable.",
+        "iterable_item_removed": "Item {diff_path} removed from iterable.",
+        "attribute_added": "Attribute {diff_path} added.",
+        "attribute_removed": "Attribute {diff_path} removed.",
+        "set_item_added": "Item [{val_t2}] added to set.",
+        "set_item_removed": "Item [{val_t1}] removed from set.",
+        "repetition_change": "Repetition change for item {diff_path}.",
+             }
+
+    return texts.get(diff.report_type, "").format(diff_path=diff_path, type_t1=type_t1, type_t2=type_t2, val_t1=val_t1,
+                                                  val_t2=val_t2)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -723,7 +723,8 @@ class DeepDiff(ResultDict, Base):
 
     def pretty_form(self):
         result = []
-        for key in self.tree.keys():
+        keys = sorted(self.tree.keys())  # sorting keys to guarantee constant order in Python<3.7
+        for key in keys:
             for item_key in self.tree[key]:
                 result += [pretty_print_diff(item_key)]
 
@@ -736,6 +737,18 @@ def pretty_print_diff(diff: DiffLevel):
                f' and value changed from {str(diff.t1)} to {str(diff.t2)}'
     elif diff.report_type == "values_changed":
         return f'Value of {diff.path(root="")} changed from {str(diff.t1)} to {str(diff.t2)}'
+    elif diff.report_type == "dictionary_item_added":
+        return f'Item {diff.path(root="")} added to dictionary.'
+    elif diff.report_type == "dictionary_item_removed":
+        return f'Item {diff.path(root="")} removed from dictionary.'
+    elif diff.report_type == "iterable_item_added":
+        return f'Item {diff.path(root="")} added to iterable.'
+    elif diff.report_type == "iterable_item_removed":
+        return f'Item {diff.path(root="")} removed from iterable.'
+    elif diff.report_type == "attribute_added":
+        return f'Attribute {diff.path(root="root")} added.'
+    elif diff.report_type == "attribute_removed":
+        return f'Attribute {diff.path(root="root")} removed.'
     else:
         return ''
 

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -741,8 +741,8 @@ def pretty_print_diff(diff: DiffLevel):
     diff_path = diff.path(root='root')
 
     texts = {
-        "type_changes": "Type of {diff_path} changed from {type_t1} to {type_t2} and value changed from {val_t1} to {val_t2}",
-        "values_changed": "Value of {diff_path} changed from {val_t1} to {val_t2}",
+        "type_changes": "Type of {diff_path} changed from {type_t1} to {type_t2} and value changed from {val_t1} to {val_t2}.",
+        "values_changed": "Value of {diff_path} changed from {val_t1} to {val_t2}.",
         "dictionary_item_added": "Item {diff_path} added to dictionary.",
         "dictionary_item_removed": "Item {diff_path} removed from dictionary.",
         "iterable_item_added": "Item {diff_path} added to iterable.",

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -732,11 +732,24 @@ class DeepDiff(ResultDict, Base):
 
 
 def pretty_print_diff(diff: DiffLevel):
+    type_t1 = get_type(diff.t1).__name__
+    type_t2 = get_type(diff.t2).__name__
+
+    if type_t1 == "str":
+        val_t1 = f'"{str(diff.t1)}"'
+    else:
+        val_t1 = str(diff.t1)
+
+    if type_t2 == "str":
+        val_t2 = f'"{str(diff.t2)}"'
+    else:
+        val_t2 = str(diff.t2)
+
     if diff.report_type == "type_changes":
-        return f'Type of {diff.path(root="")} changed from {type(diff.t1).__name__} to {type(diff.t2).__name__}' \
-               f' and value changed from {str(diff.t1)} to {str(diff.t2)}'
+        return f'Type of {diff.path(root="")} changed from {type_t1} to {type_t2}' \
+               f' and value changed from {val_t1} to {val_t2}'
     elif diff.report_type == "values_changed":
-        return f'Value of {diff.path(root="")} changed from {str(diff.t1)} to {str(diff.t2)}'
+        return f'Value of {diff.path(root="")} changed from {val_t1} to {val_t2}'
     elif diff.report_type == "dictionary_item_added":
         return f'Item {diff.path(root="")} added to dictionary.'
     elif diff.report_type == "dictionary_item_removed":
@@ -750,9 +763,9 @@ def pretty_print_diff(diff: DiffLevel):
     elif diff.report_type == "attribute_removed":
         return f'Attribute {diff.path(root="root")} removed.'
     elif diff.report_type == "set_item_added":
-        return f'Item [{str(diff.t2)}] added to set.'
+        return f'Item [{val_t2}] added to set.'
     elif diff.report_type == "set_item_removed":
-        return f'Item [{str(diff.t1)}] removed from set.'
+        return f'Item [{val_t1}] removed from set.'
     elif diff.report_type == "repetition_change":
         return f'Repetition change for item {diff.path(root="")}.'
     else:

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -774,13 +774,13 @@ class DeepDiff(ResultDict, Base):
         if self.ignore_order:
             result['ignore_order'] = True
         return result
-      
+
     def pretty_form(self):
-      result = []
-      keys = sorted(self.tree.keys())  # sorting keys to guarantee constant order in Python<3.7
-      for key in keys:
-          for item_key in self.tree[key]:
-              result += [pretty_print_diff(item_key)]
+        result = []
+        keys = sorted(self.tree.keys())  # sorting keys to guarantee constant order in Python<3.7
+        for key in keys:
+            for item_key in self.tree[key]:
+                result += [pretty_print_diff(item_key)]
 
         return '\n'.join(result)
 
@@ -806,10 +806,11 @@ def pretty_print_diff(diff: DiffLevel):
         "set_item_added": "Item root[{val_t2}] added to set.",
         "set_item_removed": "Item root[{val_t1}] removed from set.",
         "repetition_change": "Repetition change for item {diff_path}.",
-             }
+    }
 
     return texts.get(diff.report_type, "").format(diff_path=diff_path, type_t1=type_t1, type_t2=type_t2, val_t1=val_t1,
                                                   val_t2=val_t2)
+
 
 if __name__ == "__main__":  # pragma: no cover
     import doctest

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -789,8 +789,8 @@ def pretty_print_diff(diff: DiffLevel):
     type_t1 = get_type(diff.t1).__name__
     type_t2 = get_type(diff.t2).__name__
 
-    val_t1 = f'"{str(diff.t1)}"' if type_t1 == "str" else str(diff.t1)
-    val_t2 = f'"{str(diff.t2)}"' if type_t2 == "str" else str(diff.t2)
+    val_t1 = '"{}"'.format(str(diff.t1)) if type_t1 == "str" else str(diff.t1)
+    val_t2 = '"{}"'.format(str(diff.t2)) if type_t2 == "str" else str(diff.t2)
 
     diff_path = diff.path(root='root')
 

--- a/tests/test_diff_tree.py
+++ b/tests/test_diff_tree.py
@@ -205,7 +205,7 @@ class TestDeepDiffPrettyForm:
                                             new_val_displayed):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['type_changes'].items[0])
-        assert result == f'Type of {item_path} changed from {old_type} to {new_type} and value changed from {old_val_displayed} to {new_val_displayed}'
+        assert result == f'Type of {item_path} changed from {old_type} to {new_type} and value changed from {old_val_displayed} to {new_val_displayed}.'
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
@@ -233,7 +233,7 @@ class TestDeepDiffPrettyForm:
     def test_pretty_print_diff_values_changed(self, t1, t2, item_path, old_val_displayed, new_val_displayed):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['values_changed'].items[0])
-        assert result == f'Value of {item_path} changed from {old_val_displayed} to {new_val_displayed}'
+        assert result == f'Value of {item_path} changed from {old_val_displayed} to {new_val_displayed}.'
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
@@ -306,7 +306,7 @@ class TestDeepDiffPrettyForm:
         expected = (
             'Item root[5] added to dictionary.'
             '\nItem root[3] removed from dictionary.'
-            '\nType of root[2] changed from int to str and value changed from 2 to "b"'
-            '\nValue of root[4] changed from 4 to 5'
+            '\nType of root[2] changed from int to str and value changed from 2 to "b".'
+            '\nValue of root[4] changed from 4 to 5.'
         )
         assert result == expected

--- a/tests/test_diff_tree.py
+++ b/tests/test_diff_tree.py
@@ -266,6 +266,51 @@ class TestDeepDiffPrettyForm:
         result = pretty_print_diff(ddiff.tree['attribute_added'].items[0])
         assert result == f'Attribute {item_path} added.'
 
+    @pytest.mark.parametrize('t1, t2, item_path',
+                             [
+                                 [[1, 2, 3], [1, 2], 'root.two'],
+                             ]
+                             )
+    def test_pretty_print_diff_attribute_removed(self, t1, t2, item_path):
+        cls = self.get_testing_class()
+        t1 = cls()
+        t1.two = 2
+        t2 = cls()
+
+        ddiff = DeepDiff(t1, t2, view='tree')
+        result = pretty_print_diff(ddiff.tree['attribute_removed'].items[0])
+        assert result == f'Attribute {item_path} removed.'
+
+    @pytest.mark.parametrize('t1, t2, item_path',
+                             [
+                                 [{1, 2}, {1, 2, 3}, '[3]'],
+                             ]
+                             )
+    def test_pretty_print_diff_set_item_added(self, t1, t2, item_path):
+        ddiff = DeepDiff(t1, t2, view='tree')
+        result = pretty_print_diff(ddiff.tree['set_item_added'].items[0])
+        assert result == f'Item {item_path} added to set.'
+
+    @pytest.mark.parametrize('t1, t2, item_path',
+                             [
+                                 [{1, 2, 3}, {1, 2}, '[3]'],
+                             ]
+                             )
+    def test_pretty_print_diff_set_item_removed(self, t1, t2, item_path):
+        ddiff = DeepDiff(t1, t2, view='tree')
+        result = pretty_print_diff(ddiff.tree['set_item_removed'].items[0])
+        assert result == f'Item {item_path} removed from set.'
+
+    @pytest.mark.parametrize('t1, t2, item_path',
+                             [
+                                 [[1, 2, 3, 2], [1, 2, 3], '[1]'],
+                             ]
+                             )
+    def test_pretty_print_diff_repetition_change(self, t1, t2, item_path):
+        ddiff = DeepDiff(t1, t2, view='tree', ignore_order=True, report_repetition=True)
+        result = pretty_print_diff(ddiff.tree['repetition_change'].items[0])
+        assert result == f'Repetition change for item {item_path}.'
+
     def test_pretty_form_method(self):
         t1 = {2: 2, 4: 4}
         t2 = {2: 'b', 4: 5}

--- a/tests/test_diff_tree.py
+++ b/tests/test_diff_tree.py
@@ -184,3 +184,16 @@ class TestDeepAdditions:
         ddiff = DeepDiff(t1, t2, view='tree')
         addition = ddiff + t1
         assert addition == t2
+
+
+class TestDeepDiffPrettyForm:
+    """Tests for pretty_form() method of DeepDiff"""
+
+    @pytest.mark.parametrize('t1, t2, changed_item, old_type, new_type, old_val_displayed, new_val_displayed',
+                             [
+                                 [{2: 2, 4: 4}, {2: 'b', 5: 5}, '[2]', 'int', 'str', '2', '"b"'],
+                             ]
+                             )
+    def test_pretty_form_type_and_value_changes(self, t1, t2, changed_item, old_type, new_type, old_val_displayed, new_val_displayed):
+        ddiff = DeepDiff(t1, t2, view='tree')
+        assert ddiff.pretty_form() == f'Type of {changed_item} changed from {old_type} to {new_type} and value changed from {old_val_displayed} to {new_val_displayed}'

--- a/tests/test_diff_tree.py
+++ b/tests/test_diff_tree.py
@@ -121,6 +121,8 @@ class TestDeepDiffTree:
         assert change.path() is None
         assert change.path(force='yes') == 'root(unrepresentable)'
         assert change.path(force='fake') == 'root[2]'
+        print(ddiff.pretty_form())
+        a="a"
 
     def test_significant_digits(self):
         ddiff = DeepDiff(
@@ -192,8 +194,9 @@ class TestDeepDiffPrettyForm:
 
     @pytest.mark.parametrize('t1, t2, item_path, old_type, new_type, old_val_displayed, new_val_displayed',
                              [
-                                 [{2: 2, 4: 4}, {2: 'b', 4: 4}, '[2]', 'int', 'str', '2', '"b"'],
-                                 [[1, 2, 3], [1, '2', 3], '[1]', 'int', 'str', '2', '"2"'],
+                                 [{2: 2, 4: 4}, {2: 'b', 4: 4}, 'root[2]', 'int', 'str', '2', '"b"'],
+                                 [[1, 2, 3], [1, '2', 3], 'root[1]', 'int', 'str', '2', '"2"'],
+                                 [[1, 2, 3], {1, 2, 3}, 'root', 'list', 'set', '[1, 2, 3]', '{1, 2, 3}']
                              ])
     def test_pretty_print_diff_type_changes(self, t1, t2, item_path, old_type, new_type, old_val_displayed,
                                             new_val_displayed):
@@ -203,7 +206,7 @@ class TestDeepDiffPrettyForm:
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
-                                 [{2: 2, 4: 4}, {2: 2, 4: 4, 5: 5}, '[5]'],
+                                 [{2: 2, 4: 4}, {2: 2, 4: 4, 5: 5}, 'root[5]'],
                              ])
     def test_pretty_print_diff_dictionary_item_added(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
@@ -212,7 +215,7 @@ class TestDeepDiffPrettyForm:
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
-                                 [{2: 2, 4: 4}, {2: 2}, '[4]'],
+                                 [{2: 2, 4: 4}, {2: 2}, 'root[4]'],
                              ])
     def test_pretty_print_diff_dictionary_item_removed(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
@@ -221,8 +224,8 @@ class TestDeepDiffPrettyForm:
 
     @pytest.mark.parametrize('t1, t2, item_path, old_val_displayed, new_val_displayed',
                              [
-                                 [{2: 2, 4: 4}, {2: 3, 4: 4}, '[2]', '2', '3'],
-                                 [['a', 'b', 'c'], ['a', 'b', 'd'], '[2]', '"c"', '"d"']
+                                 [{2: 2, 4: 4}, {2: 3, 4: 4}, 'root[2]', '2', '3'],
+                                 [['a', 'b', 'c'], ['a', 'b', 'd'], 'root[2]', '"c"', '"d"']
                              ])
     def test_pretty_print_diff_values_changed(self, t1, t2, item_path, old_val_displayed, new_val_displayed):
         ddiff = DeepDiff(t1, t2, view='tree')
@@ -231,7 +234,7 @@ class TestDeepDiffPrettyForm:
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
-                                 [[1, 2, 3], [1, 2, 3, 4], '[3]'],
+                                 [[1, 2, 3], [1, 2, 3, 4], 'root[3]'],
                              ])
     def test_pretty_print_diff_iterable_item_added(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
@@ -240,7 +243,7 @@ class TestDeepDiffPrettyForm:
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
-                                 [[1, 2, 3], [1, 2], '[2]'],
+                                 [[1, 2, 3], [1, 2], 'root[2]'],
                              ])
     def test_pretty_print_diff_iterable_item_removed(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
@@ -277,7 +280,7 @@ class TestDeepDiffPrettyForm:
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
-                                 [{1, 2}, {1, 2, 3}, '[3]'],
+                                 [{1, 2}, {1, 2, 3}, 'root[3]'],
                              ])
     def test_pretty_print_diff_set_item_added(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
@@ -286,7 +289,7 @@ class TestDeepDiffPrettyForm:
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
-                                 [{1, 2, 3}, {1, 2}, '[3]'],
+                                 [{1, 2, 3}, {1, 2}, 'root[3]'],
                              ])
     def test_pretty_print_diff_set_item_removed(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
@@ -295,7 +298,7 @@ class TestDeepDiffPrettyForm:
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
-                                 [[1, 2, 3, 2], [1, 2, 3], '[1]'],
+                                 [[1, 2, 3, 2], [1, 2, 3], 'root[1]'],
                              ])
     def test_pretty_print_diff_repetition_change(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree', ignore_order=True, report_repetition=True)
@@ -307,8 +310,8 @@ class TestDeepDiffPrettyForm:
         t2 = {2: 'b', 4: 5}
         ddiff = DeepDiff(t1, t2, view='tree')
         result = ddiff.pretty_form()
-        expected = ('Type of [2] changed from int to str and value changed from 2 to "b"'
-                    "\nValue of [4] changed from 4 to 5")
+        expected = ('Type of root[2] changed from int to str and value changed from 2 to "b"'
+                    "\nValue of root[4] changed from 4 to 5")
         assert result == expected
 
     @staticmethod

--- a/tests/test_diff_tree.py
+++ b/tests/test_diff_tree.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import pytest
 from deepdiff import DeepDiff
+from deepdiff.diff import pretty_print_diff
 from deepdiff.helper import pypy3, notpresent
 from deepdiff.model import DictRelationship, NonSubscriptableIterableRelationship
 
@@ -191,9 +192,20 @@ class TestDeepDiffPrettyForm:
 
     @pytest.mark.parametrize('t1, t2, changed_item, old_type, new_type, old_val_displayed, new_val_displayed',
                              [
-                                 [{2: 2, 4: 4}, {2: 'b', 5: 5}, '[2]', 'int', 'str', '2', '"b"'],
+                                 [{2: 2, 4: 4}, {2: 'b', 4: 4}, '[2]', 'int', 'str', '2', 'b'],
                              ]
                              )
-    def test_pretty_form_type_and_value_changes(self, t1, t2, changed_item, old_type, new_type, old_val_displayed, new_val_displayed):
+    def test_pretty_print_diff_type_and_value_changes(self, t1, t2, changed_item, old_type, new_type, old_val_displayed,
+                                                      new_val_displayed):
         ddiff = DeepDiff(t1, t2, view='tree')
-        assert ddiff.pretty_form() == f'Type of {changed_item} changed from {old_type} to {new_type} and value changed from {old_val_displayed} to {new_val_displayed}'
+        result = pretty_print_diff(ddiff.tree['type_changes'].items[0])
+        assert result == f'Type of {changed_item} changed from {old_type} to {new_type} and value changed from {old_val_displayed} to {new_val_displayed}'
+
+    def test_pretty_form_method(self):
+        t1 = {2: 2, 4: 4}
+        t2 = {2: 'b', 4: 5}
+        ddiff = DeepDiff(t1, t2, view='tree')
+        result = ddiff.pretty_form()
+        expected = ("Value of [4] changed from 4 to 5"
+                    "\nType of [2] changed from int to str and value changed from 2 to b")
+        assert result == expected

--- a/tests/test_diff_tree.py
+++ b/tests/test_diff_tree.py
@@ -192,11 +192,11 @@ class TestDeepDiffPrettyForm:
 
     @pytest.mark.parametrize('t1, t2, item_path, old_type, new_type, old_val_displayed, new_val_displayed',
                              [
-                                 [{2: 2, 4: 4}, {2: 'b', 4: 4}, '[2]', 'int', 'str', '2', 'b'],
-                             ]
-                             )
+                                 [{2: 2, 4: 4}, {2: 'b', 4: 4}, '[2]', 'int', 'str', '2', '"b"'],
+                                 [[1, 2, 3], [1, '2', 3], '[1]', 'int', 'str', '2', '"2"'],
+                             ])
     def test_pretty_print_diff_type_changes(self, t1, t2, item_path, old_type, new_type, old_val_displayed,
-                                                      new_val_displayed):
+                                            new_val_displayed):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['type_changes'].items[0])
         assert result == f'Type of {item_path} changed from {old_type} to {new_type} and value changed from {old_val_displayed} to {new_val_displayed}'
@@ -204,8 +204,7 @@ class TestDeepDiffPrettyForm:
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
                                  [{2: 2, 4: 4}, {2: 2, 4: 4, 5: 5}, '[5]'],
-                             ]
-                             )
+                             ])
     def test_pretty_print_diff_dictionary_item_added(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['dictionary_item_added'].items[0])
@@ -214,8 +213,7 @@ class TestDeepDiffPrettyForm:
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
                                  [{2: 2, 4: 4}, {2: 2}, '[4]'],
-                             ]
-                             )
+                             ])
     def test_pretty_print_diff_dictionary_item_removed(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['dictionary_item_removed'].items[0])
@@ -224,8 +222,8 @@ class TestDeepDiffPrettyForm:
     @pytest.mark.parametrize('t1, t2, item_path, old_val_displayed, new_val_displayed',
                              [
                                  [{2: 2, 4: 4}, {2: 3, 4: 4}, '[2]', '2', '3'],
-                             ]
-                             )
+                                 [['a', 'b', 'c'], ['a', 'b', 'd'], '[2]', '"c"', '"d"']
+                             ])
     def test_pretty_print_diff_values_changed(self, t1, t2, item_path, old_val_displayed, new_val_displayed):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['values_changed'].items[0])
@@ -234,8 +232,7 @@ class TestDeepDiffPrettyForm:
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
                                  [[1, 2, 3], [1, 2, 3, 4], '[3]'],
-                             ]
-                             )
+                             ])
     def test_pretty_print_diff_iterable_item_added(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['iterable_item_added'].items[0])
@@ -244,8 +241,7 @@ class TestDeepDiffPrettyForm:
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
                                  [[1, 2, 3], [1, 2], '[2]'],
-                             ]
-                             )
+                             ])
     def test_pretty_print_diff_iterable_item_removed(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['iterable_item_removed'].items[0])
@@ -254,8 +250,7 @@ class TestDeepDiffPrettyForm:
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
                                  [[1, 2, 3], [1, 2], 'root.two'],
-                             ]
-                             )
+                             ])
     def test_pretty_print_diff_attribute_added(self, t1, t2, item_path):
         cls = self.get_testing_class()
         t1 = cls()
@@ -269,8 +264,7 @@ class TestDeepDiffPrettyForm:
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
                                  [[1, 2, 3], [1, 2], 'root.two'],
-                             ]
-                             )
+                             ])
     def test_pretty_print_diff_attribute_removed(self, t1, t2, item_path):
         cls = self.get_testing_class()
         t1 = cls()
@@ -284,8 +278,7 @@ class TestDeepDiffPrettyForm:
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
                                  [{1, 2}, {1, 2, 3}, '[3]'],
-                             ]
-                             )
+                             ])
     def test_pretty_print_diff_set_item_added(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['set_item_added'].items[0])
@@ -294,8 +287,7 @@ class TestDeepDiffPrettyForm:
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
                                  [{1, 2, 3}, {1, 2}, '[3]'],
-                             ]
-                             )
+                             ])
     def test_pretty_print_diff_set_item_removed(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['set_item_removed'].items[0])
@@ -304,8 +296,7 @@ class TestDeepDiffPrettyForm:
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
                                  [[1, 2, 3, 2], [1, 2, 3], '[1]'],
-                             ]
-                             )
+                             ])
     def test_pretty_print_diff_repetition_change(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree', ignore_order=True, report_repetition=True)
         result = pretty_print_diff(ddiff.tree['repetition_change'].items[0])
@@ -316,7 +307,7 @@ class TestDeepDiffPrettyForm:
         t2 = {2: 'b', 4: 5}
         ddiff = DeepDiff(t1, t2, view='tree')
         result = ddiff.pretty_form()
-        expected = ("Type of [2] changed from int to str and value changed from 2 to b"
+        expected = ('Type of [2] changed from int to str and value changed from 2 to "b"'
                     "\nValue of [4] changed from 4 to 5")
         assert result == expected
 

--- a/tests/test_diff_tree.py
+++ b/tests/test_diff_tree.py
@@ -121,8 +121,6 @@ class TestDeepDiffTree:
         assert change.path() is None
         assert change.path(force='yes') == 'root(unrepresentable)'
         assert change.path(force='fake') == 'root[2]'
-        print(ddiff.pretty_form())
-        a="a"
 
     def test_significant_digits(self):
         ddiff = DeepDiff(
@@ -192,6 +190,11 @@ class TestDeepAdditions:
 class TestDeepDiffPrettyForm:
     """Tests for pretty_form() method of DeepDiff"""
 
+    class TestingClass:
+        one = 1
+
+    testing_class = TestingClass
+
     @pytest.mark.parametrize('t1, t2, item_path, old_type, new_type, old_val_displayed, new_val_displayed',
                              [
                                  [{2: 2, 4: 4}, {2: 'b', 4: 4}, 'root[2]', 'int', 'str', '2', '"b"'],
@@ -250,33 +253,23 @@ class TestDeepDiffPrettyForm:
         result = pretty_print_diff(ddiff.tree['iterable_item_removed'].items[0])
         assert result == f'Item {item_path} removed from iterable.'
 
-    @pytest.mark.parametrize('t1, t2, item_path',
-                             [
-                                 [[1, 2, 3], [1, 2], 'root.two'],
-                             ])
-    def test_pretty_print_diff_attribute_added(self, t1, t2, item_path):
-        cls = self.get_testing_class()
-        t1 = cls()
-        t2 = cls()
+    def test_pretty_print_diff_attribute_added(self):
+        t1 = self.testing_class()
+        t2 = self.testing_class()
         t2.two = 2
 
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['attribute_added'].items[0])
-        assert result == f'Attribute {item_path} added.'
+        assert result == 'Attribute root.two added.'
 
-    @pytest.mark.parametrize('t1, t2, item_path',
-                             [
-                                 [[1, 2, 3], [1, 2], 'root.two'],
-                             ])
-    def test_pretty_print_diff_attribute_removed(self, t1, t2, item_path):
-        cls = self.get_testing_class()
-        t1 = cls()
+    def test_pretty_print_diff_attribute_removed(self):
+        t1 = self.testing_class()
         t1.two = 2
-        t2 = cls()
+        t2 = self.testing_class()
 
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['attribute_removed'].items[0])
-        assert result == f'Attribute {item_path} removed.'
+        assert result == f'Attribute root.two removed.'
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
@@ -306,17 +299,14 @@ class TestDeepDiffPrettyForm:
         assert result == f'Repetition change for item {item_path}.'
 
     def test_pretty_form_method(self):
-        t1 = {2: 2, 4: 4}
-        t2 = {2: 'b', 4: 5}
+        t1 = {2: 2, 3: 3, 4: 4}
+        t2 = {2: 'b', 4: 5, 5: 5}
         ddiff = DeepDiff(t1, t2, view='tree')
         result = ddiff.pretty_form()
-        expected = ('Type of root[2] changed from int to str and value changed from 2 to "b"'
-                    "\nValue of root[4] changed from 4 to 5")
+        expected = (
+            'Item root[5] added to dictionary.'
+            '\nItem root[3] removed from dictionary.'
+            '\nType of root[2] changed from int to str and value changed from 2 to "b"'
+            '\nValue of root[4] changed from 4 to 5'
+        )
         assert result == expected
-
-    @staticmethod
-    def get_testing_class():
-        class TestingClass:
-            one = 1
-
-        return TestingClass

--- a/tests/test_diff_tree.py
+++ b/tests/test_diff_tree.py
@@ -190,22 +190,94 @@ class TestDeepAdditions:
 class TestDeepDiffPrettyForm:
     """Tests for pretty_form() method of DeepDiff"""
 
-    @pytest.mark.parametrize('t1, t2, changed_item, old_type, new_type, old_val_displayed, new_val_displayed',
+    @pytest.mark.parametrize('t1, t2, item_path, old_type, new_type, old_val_displayed, new_val_displayed',
                              [
                                  [{2: 2, 4: 4}, {2: 'b', 4: 4}, '[2]', 'int', 'str', '2', 'b'],
                              ]
                              )
-    def test_pretty_print_diff_type_and_value_changes(self, t1, t2, changed_item, old_type, new_type, old_val_displayed,
+    def test_pretty_print_diff_type_changes(self, t1, t2, item_path, old_type, new_type, old_val_displayed,
                                                       new_val_displayed):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['type_changes'].items[0])
-        assert result == f'Type of {changed_item} changed from {old_type} to {new_type} and value changed from {old_val_displayed} to {new_val_displayed}'
+        assert result == f'Type of {item_path} changed from {old_type} to {new_type} and value changed from {old_val_displayed} to {new_val_displayed}'
+
+    @pytest.mark.parametrize('t1, t2, item_path',
+                             [
+                                 [{2: 2, 4: 4}, {2: 2, 4: 4, 5: 5}, '[5]'],
+                             ]
+                             )
+    def test_pretty_print_diff_dictionary_item_added(self, t1, t2, item_path):
+        ddiff = DeepDiff(t1, t2, view='tree')
+        result = pretty_print_diff(ddiff.tree['dictionary_item_added'].items[0])
+        assert result == f'Item {item_path} added to dictionary.'
+
+    @pytest.mark.parametrize('t1, t2, item_path',
+                             [
+                                 [{2: 2, 4: 4}, {2: 2}, '[4]'],
+                             ]
+                             )
+    def test_pretty_print_diff_dictionary_item_removed(self, t1, t2, item_path):
+        ddiff = DeepDiff(t1, t2, view='tree')
+        result = pretty_print_diff(ddiff.tree['dictionary_item_removed'].items[0])
+        assert result == f'Item {item_path} removed from dictionary.'
+
+    @pytest.mark.parametrize('t1, t2, item_path, old_val_displayed, new_val_displayed',
+                             [
+                                 [{2: 2, 4: 4}, {2: 3, 4: 4}, '[2]', '2', '3'],
+                             ]
+                             )
+    def test_pretty_print_diff_values_changed(self, t1, t2, item_path, old_val_displayed, new_val_displayed):
+        ddiff = DeepDiff(t1, t2, view='tree')
+        result = pretty_print_diff(ddiff.tree['values_changed'].items[0])
+        assert result == f'Value of {item_path} changed from {old_val_displayed} to {new_val_displayed}'
+
+    @pytest.mark.parametrize('t1, t2, item_path',
+                             [
+                                 [[1, 2, 3], [1, 2, 3, 4], '[3]'],
+                             ]
+                             )
+    def test_pretty_print_diff_iterable_item_added(self, t1, t2, item_path):
+        ddiff = DeepDiff(t1, t2, view='tree')
+        result = pretty_print_diff(ddiff.tree['iterable_item_added'].items[0])
+        assert result == f'Item {item_path} added to iterable.'
+
+    @pytest.mark.parametrize('t1, t2, item_path',
+                             [
+                                 [[1, 2, 3], [1, 2], '[2]'],
+                             ]
+                             )
+    def test_pretty_print_diff_iterable_item_removed(self, t1, t2, item_path):
+        ddiff = DeepDiff(t1, t2, view='tree')
+        result = pretty_print_diff(ddiff.tree['iterable_item_removed'].items[0])
+        assert result == f'Item {item_path} removed from iterable.'
+
+    @pytest.mark.parametrize('t1, t2, item_path',
+                             [
+                                 [[1, 2, 3], [1, 2], 'root.two'],
+                             ]
+                             )
+    def test_pretty_print_diff_attribute_added(self, t1, t2, item_path):
+        cls = self.get_testing_class()
+        t1 = cls()
+        t2 = cls()
+        t2.two = 2
+
+        ddiff = DeepDiff(t1, t2, view='tree')
+        result = pretty_print_diff(ddiff.tree['attribute_added'].items[0])
+        assert result == f'Attribute {item_path} added.'
 
     def test_pretty_form_method(self):
         t1 = {2: 2, 4: 4}
         t2 = {2: 'b', 4: 5}
         ddiff = DeepDiff(t1, t2, view='tree')
         result = ddiff.pretty_form()
-        expected = ("Value of [4] changed from 4 to 5"
-                    "\nType of [2] changed from int to str and value changed from 2 to b")
+        expected = ("Type of [2] changed from int to str and value changed from 2 to b"
+                    "\nValue of [4] changed from 4 to 5")
         assert result == expected
+
+    @staticmethod
+    def get_testing_class():
+        class TestingClass:
+            one = 1
+
+        return TestingClass

--- a/tests/test_diff_tree.py
+++ b/tests/test_diff_tree.py
@@ -205,7 +205,7 @@ class TestDeepDiffPrettyForm:
                                             new_val_displayed):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['type_changes'].items[0])
-        assert result == f'Type of {item_path} changed from {old_type} to {new_type} and value changed from {old_val_displayed} to {new_val_displayed}.'
+        assert result == 'Type of {} changed from {} to {} and value changed from {} to {}.'.format(item_path, old_type, new_type, old_val_displayed, new_val_displayed)
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
@@ -214,7 +214,7 @@ class TestDeepDiffPrettyForm:
     def test_pretty_print_diff_dictionary_item_added(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['dictionary_item_added'].items[0])
-        assert result == f'Item {item_path} added to dictionary.'
+        assert result == 'Item {} added to dictionary.'.format(item_path)
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
@@ -223,7 +223,7 @@ class TestDeepDiffPrettyForm:
     def test_pretty_print_diff_dictionary_item_removed(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['dictionary_item_removed'].items[0])
-        assert result == f'Item {item_path} removed from dictionary.'
+        assert result == 'Item {} removed from dictionary.'.format(item_path)
 
     @pytest.mark.parametrize('t1, t2, item_path, old_val_displayed, new_val_displayed',
                              [
@@ -233,7 +233,7 @@ class TestDeepDiffPrettyForm:
     def test_pretty_print_diff_values_changed(self, t1, t2, item_path, old_val_displayed, new_val_displayed):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['values_changed'].items[0])
-        assert result == f'Value of {item_path} changed from {old_val_displayed} to {new_val_displayed}.'
+        assert result == 'Value of {} changed from {} to {}.'.format(item_path, old_val_displayed, new_val_displayed)
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
@@ -242,7 +242,7 @@ class TestDeepDiffPrettyForm:
     def test_pretty_print_diff_iterable_item_added(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['iterable_item_added'].items[0])
-        assert result == f'Item {item_path} added to iterable.'
+        assert result == 'Item {} added to iterable.'.format(item_path)
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
@@ -251,7 +251,7 @@ class TestDeepDiffPrettyForm:
     def test_pretty_print_diff_iterable_item_removed(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['iterable_item_removed'].items[0])
-        assert result == f'Item {item_path} removed from iterable.'
+        assert result == 'Item {} removed from iterable.'.format(item_path)
 
     def test_pretty_print_diff_attribute_added(self):
         t1 = self.testing_class()
@@ -269,7 +269,7 @@ class TestDeepDiffPrettyForm:
 
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['attribute_removed'].items[0])
-        assert result == f'Attribute root.two removed.'
+        assert result == 'Attribute root.two removed.'
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
@@ -278,7 +278,7 @@ class TestDeepDiffPrettyForm:
     def test_pretty_print_diff_set_item_added(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['set_item_added'].items[0])
-        assert result == f'Item {item_path} added to set.'
+        assert result == 'Item {} added to set.'.format(item_path)
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
@@ -287,7 +287,7 @@ class TestDeepDiffPrettyForm:
     def test_pretty_print_diff_set_item_removed(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree')
         result = pretty_print_diff(ddiff.tree['set_item_removed'].items[0])
-        assert result == f'Item {item_path} removed from set.'
+        assert result == 'Item {} removed from set.'.format(item_path)
 
     @pytest.mark.parametrize('t1, t2, item_path',
                              [
@@ -296,7 +296,7 @@ class TestDeepDiffPrettyForm:
     def test_pretty_print_diff_repetition_change(self, t1, t2, item_path):
         ddiff = DeepDiff(t1, t2, view='tree', ignore_order=True, report_repetition=True)
         result = pretty_print_diff(ddiff.tree['repetition_change'].items[0])
-        assert result == f'Repetition change for item {item_path}.'
+        assert result == 'Repetition change for item {}.'.format(item_path)
 
     def test_pretty_form_method(self):
         t1 = {2: 2, 3: 3, 4: 4}


### PR DESCRIPTION
Feature requested in issue #85 

Added method pretty_form() to DeepDiff class. Method returns a string with verbose description of changes, for example:
```
Item root[5] added to dictionary.
Item root[3] removed from dictionary.
Type of root[2] changed from int to str and value changed from 2 to "b".
Value of root[4] changed from 4 to 5.
```

There is one text pattern for each available report_type.