### PR TITLE
truncate_datetime optional parameter for datetime truncation

### DIFF
--- a/deepdiff/base.py
+++ b/deepdiff/base.py
@@ -48,3 +48,8 @@ class Base:
             ignore_type_in_groups = list(map(tuple, ignore_type_in_groups))
 
         return ignore_type_in_groups
+
+    def get_truncate_datetime(self, truncate_datetime):
+        if truncate_datetime not in (None, 'second', 'minute', 'hour', 'day'):
+            raise ValueError("truncate_datetime must be second, minute, hour or day")
+        return truncate_datetime

--- a/deepdiff/deephash_doc.rst
+++ b/deepdiff/deephash_doc.rst
@@ -73,6 +73,9 @@ significant_digits : int >= 0, default=None
 
     When you set the number_format_notation="e", we use "{:.Xe}".format(Your Number) where X=significant_digits.
 
+truncate_datetime: string, default = None
+    Can take value one of 'second', 'minute', 'hour', 'day' and truncate with this value datetime objects before hashing it
+
 number_format_notation : string, default="f"
     number_format_notation is what defines the meaning of significant digits. The default value of "f" means the digits AFTER the decimal point. "f" stands for fixed point. The other option is "e" which stands for exponent notation or scientific notation.
 

--- a/deepdiff/diff_doc.rst
+++ b/deepdiff/diff_doc.rst
@@ -23,6 +23,9 @@ report_repetition : Boolean, default=False
 significant_digits : int >= 0, default=None
     :ref:`significant_digits_label` defines the number of digits AFTER the decimal point to be used in the comparison. However you can override that by setting the number_format_notation="e" which will make it mean the digits in scientific notation.
 
+truncate_datetime: string, default = None
+    Can take value one of 'second', 'minute', 'hour', 'day' and truncate with this value datetime objects before hashing it
+
 number_format_notation : string, default="f"
     :ref:`number_format_notation_label` is what defines the meaning of significant digits. The default value of "f" means the digits AFTER the decimal point. "f" stands for fixed point. The other option is "e" which stands for exponent notation or scientific notation.
 

--- a/deepdiff/helper.py
+++ b/deepdiff/helper.py
@@ -92,6 +92,7 @@ unicode_type = str
 bytes_type = bytes
 only_numbers = (int, float, complex, Decimal) + numpy_numbers
 datetimes = (datetime.datetime, datetime.date, datetime.timedelta, datetime.time)
+times = (datetime.datetime, datetime.time)
 numbers = only_numbers + datetimes
 booleans = (bool, np_bool_)
 
@@ -508,6 +509,23 @@ TYPES_TO_DIST_FUNC = [
     (datetime.timedelta, _get_timedelta_distance),
     (datetime.time, _get_time_distance),
 ]
+
+
+def datetime_normalize(truncate_datetime, obj):
+    if truncate_datetime:
+        if truncate_datetime == 'second':
+            obj = obj.replace(microsecond=0)
+        elif truncate_datetime == 'minute':
+            obj = obj.replace(second=0, microsecond=0)
+        elif truncate_datetime == 'hour':
+            obj = obj.replace(minute=0, second=0, microsecond=0)
+        elif truncate_datetime == 'day':
+            obj = obj.replace(hour=0, minute=0, second=0, microsecond=0)
+    if isinstance(obj, datetime.datetime):
+        obj = obj.replace(tzinfo=datetime.timezone.utc).timestamp()
+    elif isinstance(obj, datetime.time):
+        obj = time_to_seconds(obj)
+    return obj
 
 
 def get_numeric_types_distance(num1, num2, max_):

--- a/tests/test_diff_other.py
+++ b/tests/test_diff_other.py
@@ -1,4 +1,5 @@
 import pytest
+import datetime
 from time import sleep
 from unittest import mock
 from deepdiff.model import DiffLevel
@@ -30,3 +31,21 @@ class TestDiffOther:
         with pytest.raises(ValueError) as excinfo:
             DeepDiff(t1, t2, view='blah')
         assert str(excinfo.value) == INVALID_VIEW_MSG.format('blah')
+
+    def test_truncate_datetime(self):
+        d1 = {'a' : datetime.datetime(2020, 5, 17, 22, 15, 34, 913070)}
+        d2 = {'a' : datetime.datetime(2020, 5, 17, 22, 15, 39, 296583)}
+        res = DeepDiff(d1, d2, truncate_datetime='minute')
+        assert res == {}
+
+        res = DeepDiff(d1, d2, truncate_datetime='second')
+        assert res['values_changed']["root['a']"]['new_value'] == 1589753739.0
+
+        d1 = {'a' : datetime.time(22, 15, 34, 913070)}
+        d2 = {'a' : datetime.time(22, 15, 39, 296583)}
+
+        res = DeepDiff(d1, d2, truncate_datetime='minute')
+        assert res == {}
+
+        res = DeepDiff(d1, d2, truncate_datetime='second')
+        assert res['values_changed']["root['a']"]['new_value'] == 80139

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -2,6 +2,7 @@
 import re
 import pytest
 import logging
+import datetime
 from collections import namedtuple
 from functools import partial
 from enum import Enum
@@ -76,6 +77,26 @@ class TestDeepHash:
         result = DeepHash(obj)
         with pytest.raises(KeyError):
             result[2]
+
+    def test_datetime(self):
+        now = datetime.datetime.now()
+        a = b = now
+        a_hash = DeepHash(a)
+        b_hash = DeepHash(b)
+        assert a_hash[a] == b_hash[b]
+
+    def test_datetime_truncate(self):
+        a = datetime.datetime(2020, 5, 17, 22, 15, 34, 913070)
+        b = datetime.datetime(2020, 5, 17, 22, 15, 39, 296583)
+        c = datetime.datetime(2020, 5, 17, 22, 15, 34, 500000)
+
+        a_hash = DeepHash(a, truncate_datetime='minute')
+        b_hash = DeepHash(b, truncate_datetime='minute')
+        assert a_hash[a] == b_hash[b]
+
+        a_hash = DeepHash(a, truncate_datetime='second')
+        c_hash = DeepHash(c, truncate_datetime='second')
+        assert a_hash[a] == c_hash[c]
 
     def test_get_reserved_keyword(self):
         hashes = {UNPROCESSED_KEY: 'full item', 'key1': ('item', 'count')}


### PR DESCRIPTION
Add truncate_datetime optional parameter to truncate datetime.datetime and datetime.time objects before comparing and hashing.  It is can be useful when you want to diff datetimes or time that are a little bit different from each other (few milliseconds, seconds, e.t.c) but truncation will make them the same.
