### PR TITLE
Travis-ci: added ppc64le support along with amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,26 @@ cache: pip
 matrix:
   include:
     - python: 3.5
+      arch: amd64
     - python: 3.6
+      arch: amd64
     - python: pypy3
+      arch: amd64
     - python: 3.7
+      arch: amd64
     - python: 3.8
-
+      arch: amd64
+    - python: 3.5
+      arch: ppc64le
+    - python: 3.6
+      arch: ppc64le
+    - python: 3.7
+      arch: ppc64le
+    - python: 3.8
+      arch: ppc64le
+      
+before_install:
+  - sudo chown -Rvf $USER:$GROUP ~/.cache/pip/wheels
 install:
   - pip install -r requirements-dev.txt
 


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjay-cpu/deepdiff/builds/186228453 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Note: I had not included python:pypy3 for ppc64le build as it has no ppc64le support.

Thanks !!