### PR TITLE
Improve ignoring of NoneType in diff

### DIFF
--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -1139,9 +1139,10 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
             if report_type_change:
                 self.__diff_types(level)
                 return
-            # This is an edge case where t1=None and None is in the ignore type group.
-            if level.t1 is None:
+            # This is an edge case where t1=None or t2=None and None is in the ignore type group.
+            if level.t1 is None or level.t2 is None:
                 self.__report_result('values_changed', level)
+                return
 
         if self.ignore_nan_inequality and isinstance(level.t1, float) and str(level.t1) == str(level.t2) == 'nan':
             return

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -584,11 +584,17 @@ class TestDeepDiffText:
         }
         assert result == ddiff1
 
-        ddiff2 = DeepDiff({'a': None}, {'a': 1}, ignore_type_subclasses=True, ignore_type_in_groups=[(int, float, None)])
-        assert {'values_changed': {"root['a']": {'new_value': 1, 'old_value': None}}} == ddiff2
+        ddiff2 = DeepDiff({'a': None}, {'a': '1'}, ignore_type_subclasses=True, ignore_type_in_groups=[(str, int, float, None)])
+        assert {'values_changed': {"root['a']": {'new_value': '1', 'old_value': None}}} == ddiff2
 
-        ddiff3 = DeepDiff({'a': 1}, {'a': None}, ignore_type_subclasses=True, ignore_type_in_groups=[(int, float, None)])
-        assert {'values_changed': {"root['a']": {'new_value': None, 'old_value': 1}}} == ddiff3
+        ddiff3 = DeepDiff({'a': '1'}, {'a': None}, ignore_type_subclasses=True, ignore_type_in_groups=[(str, int, float, None)])
+        assert {'values_changed': {"root['a']": {'new_value': None, 'old_value': '1'}}} == ddiff3
+
+        ddiff4 = DeepDiff({'a': {'b': None}}, {'a': {'b': '1'}}, ignore_type_subclasses=True, ignore_type_in_groups=[(str, int, float, None)])
+        assert {'values_changed': {"root['a']['b']": {'new_value': '1', 'old_value': None}}} == ddiff4
+
+        ddiff5 = DeepDiff({'a': {'b': '1'}}, {'a': {'b': None}}, ignore_type_subclasses=True, ignore_type_in_groups=[(str, int, float, None)])
+        assert {'values_changed': {"root['a']['b']": {'new_value': None, 'old_value': '1'}}} == ddiff5
 
     def test_custom_object_changes_when_ignore_type_in_groups(self):
         class ClassA:


### PR DESCRIPTION
Instead of just checking t1, we also check t2, to ensure we survive
diffs where both the old and the new value can be None.

Also, as far as I can understand the code, we exit upon reporting a
result in the case of a type mismatch rather than continuing the diff
code (that way we don't need each type-specific differ to handle
incorrect types – None, in this case).

Further iteration from 47a141ffebf036f413ae0972abc4a35b8695f631.

The expanded test coverage fails on master.