### PR TITLE
add math_epsilon for number diffs that are close 

### DIFF
--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -1000,6 +1000,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
         t2_type = "number" if self.ignore_numeric_type_changes else level.t2.__class__.__name__
 
         if self.math_close is True:
+            print("MATH_CLOSE: {}, {}, {}".format(level.t1, level.t2, self.epsilon))
             if not is_close(level.t1, level.t2, abs_tol=self.epsilon):
                 self.__report_result('values_changed', level)
         elif self.significant_digits is None:

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -1000,7 +1000,6 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
         t2_type = "number" if self.ignore_numeric_type_changes else level.t2.__class__.__name__
 
         if self.math_close is True:
-            print("MATH_CLOSE: {}, {}, {}".format(level.t1, level.t2, self.epsilon))
             if not is_close(level.t1, level.t2, abs_tol=self.epsilon):
                 self.__report_result('values_changed', level)
         elif self.significant_digits is None:

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -110,7 +110,6 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
                  cache_size=0,
                  cache_tuning_sample_size=0,
                  cache_purge_level=1,
-                 epsilon=0,
                  exclude_paths=None,
                  exclude_regex_paths=None,
                  exclude_types=None,
@@ -128,7 +127,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
                  ignore_nan_inequality=False,
                  ignore_private_variables=True,
                  log_frequency_in_sec=0,
-                 math_close=False,
+                 math_epsilon=None,
                  max_passes=10000000,
                  max_diffs=None,
                  number_format_notation="f",
@@ -154,7 +153,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
                 "view, hasher, hashes, max_passes, max_diffs, "
                 "cutoff_distance_for_pairs, cutoff_intersection_for_pairs, log_frequency_in_sec, cache_size, "
                 "cache_tuning_sample_size, get_deep_distance, group_by, cache_purge_level, "
-                "math_close, epsilon, "
+                "math_epsilon, "
                 "_original_type, _parameters and _shared_parameters.") % ', '.join(kwargs.keys()))
 
         if _parameters:
@@ -189,8 +188,9 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
             self.cache_tuning_sample_size = cache_tuning_sample_size
 
             self.significant_digits = self.get_significant_digits(significant_digits, ignore_numeric_type_changes)
-            self.math_close = math_close
-            self.epsilon = epsilon
+            self.math_epsilon = math_epsilon
+            if self.math_epsilon != None and self.ignore_order:
+                logger.warning("math_epsilon will be ignored. It cannot be used when ignore_order is True.")
             self.truncate_datetime = get_truncate_datetime(truncate_datetime)
             self.number_format_notation = number_format_notation
             if verbose_level in {0, 1, 2}:
@@ -1000,8 +1000,8 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
         t1_type = "number" if self.ignore_numeric_type_changes else level.t1.__class__.__name__
         t2_type = "number" if self.ignore_numeric_type_changes else level.t2.__class__.__name__
 
-        if self.math_close is True:
-            if not is_close(level.t1, level.t2, abs_tol=self.epsilon):
+        if self.math_epsilon != None:
+            if not is_close(level.t1, level.t2, abs_tol=self.math_epsilon):
                 self.__report_result('values_changed', level)
         elif self.significant_digits is None:
             if level.t1 != level.t2:

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -110,6 +110,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
                  cache_size=0,
                  cache_tuning_sample_size=0,
                  cache_purge_level=1,
+                 epsilon=0,
                  exclude_paths=None,
                  exclude_regex_paths=None,
                  exclude_types=None,
@@ -127,6 +128,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
                  ignore_nan_inequality=False,
                  ignore_private_variables=True,
                  log_frequency_in_sec=0,
+                 math_close=False,
                  max_passes=10000000,
                  max_diffs=None,
                  number_format_notation="f",
@@ -134,8 +136,6 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
                  progress_logger=logger.info,
                  report_repetition=False,
                  significant_digits=None,
-                 math_close=False,
-                 epsilon=0,
                  truncate_datetime=None,
                  verbose_level=1,
                  view=TEXT_VIEW,
@@ -154,6 +154,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
                 "view, hasher, hashes, max_passes, max_diffs, "
                 "cutoff_distance_for_pairs, cutoff_intersection_for_pairs, log_frequency_in_sec, cache_size, "
                 "cache_tuning_sample_size, get_deep_distance, group_by, cache_purge_level, "
+                "math_close, epsilon, "
                 "_original_type, _parameters and _shared_parameters.") % ', '.join(kwargs.keys()))
 
         if _parameters:

--- a/tests/test_diff_math.py
+++ b/tests/test_diff_math.py
@@ -1,0 +1,107 @@
+import pytest
+from decimal import Decimal
+from deepdiff.diff import DeepDiff
+
+
+class TestDiffMath:
+    def test_math_diff(self):
+        """Testing for the correct setting and usage of epsilon."""
+        d1 = {"a": Decimal("3.5")}
+        d2 = {"a": Decimal("4")}
+        ep = 0.5
+        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        assert res == {}
+        d1 = {"a": Decimal("2.5")}
+        d2 = {"a": Decimal("3")}
+        ep = 0.5
+        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        assert res == {}
+        d1 = {"a": Decimal("2.5")}
+        d2 = {"a": Decimal("2")}
+        ep = 0.5
+        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        assert res == {}
+        d1 = {"a": Decimal("7.175")}
+        d2 = {"a": Decimal("7.174")}
+        ep = 0.1
+        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        assert res == {}
+        d1 = {"a": Decimal("7.175")}
+        d2 = {"a": Decimal("7.174")}
+        ep = 0.01
+        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        assert res == {}
+        d1 = {"a": Decimal("7.175")}
+        d2 = {"a": Decimal("7.174")}
+        ep = 0.001
+        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        assert res == {}
+        d1 = {"a": Decimal("7.175")}
+        d2 = {"a": Decimal("7.174")}
+        ep = 0.0001
+        expected = {
+            "values_changed": {
+                "root['a']": {
+                    "new_value": Decimal("7.174"),
+                    "old_value": Decimal("7.175"),
+                }
+            }
+        }
+        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        assert res == expected
+
+    def test_math_diff_special_case(self):
+        """Testing epsilon on a special Decimal case.
+        
+        Even though the Decimal looks different, math will evaluate it for us."""
+        d1 = {"a": Decimal("9.709999618320632")}
+        d2 = {"a": Decimal("9.710000038146973")}
+        ep = 0.001
+        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        assert res == {}
+        d1 = {"a": Decimal("9.709999618320632")}
+        d2 = {"a": Decimal("9.710000038146973")}
+        ep = 0.0001
+        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        assert res == {}
+        d1 = {"a": Decimal("9.709999618320632")}
+        d2 = {"a": Decimal("9.710000038146973")}
+        ep = 0.00001
+        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        assert res == {}
+        d1 = {"a": Decimal("9.709999618320632")}
+        d2 = {"a": Decimal("9.710000038146973")}
+        ep = 0.000001
+        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        assert res == {}
+        d1 = {"a": Decimal("9.709999618320632")}
+        d2 = {"a": Decimal("9.710000038146973")}
+        ep = 0.0000001
+        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        expected = {
+            "values_changed": {
+                "root['a']": {
+                    "new_value": Decimal("9.710000038146973"),
+                    "old_value": Decimal("9.709999618320632"),
+                }
+            }
+        }
+        assert res == expected
+
+    def test_math_diff_ignore_order(self):
+        """math_close will not work with ignore_order=true.
+        
+        Items are hashed if order is ignored, that will not work."""
+        d1 = {"a": [Decimal("9.709999618320632"), Decimal("9.709999618320632")]}
+        d2 = {"a": [Decimal("9.710000038146973"), Decimal("9.709999618320632")]}
+        ep = 0.0001
+        res = DeepDiff(d1, d2, ignore_order=False, math_close=True, epsilon=ep)
+        assert res == {}
+        d1 = {"a": [Decimal("9.709999618320632"), Decimal("9.709999618320632")]}
+        d2 = {"a": [Decimal("9.710000038146973"), Decimal("9.709999618320632")]}
+        ep = 0.0001
+        res = DeepDiff(d1, d2, ignore_order=True, math_close=True, epsilon=ep)
+        expected = {
+            "iterable_item_added": {"root['a'][0]": Decimal("9.710000038146973")}
+        }
+        assert res == expected

--- a/tests/test_diff_math.py
+++ b/tests/test_diff_math.py
@@ -9,32 +9,32 @@ class TestDiffMath:
         d1 = {"a": Decimal("3.5")}
         d2 = {"a": Decimal("4")}
         ep = 0.5
-        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        res = DeepDiff(d1, d2, math_epsilon=ep)
         assert res == {}
         d1 = {"a": Decimal("2.5")}
         d2 = {"a": Decimal("3")}
         ep = 0.5
-        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        res = DeepDiff(d1, d2, math_epsilon=ep)
         assert res == {}
         d1 = {"a": Decimal("2.5")}
         d2 = {"a": Decimal("2")}
         ep = 0.5
-        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        res = DeepDiff(d1, d2, math_epsilon=ep)
         assert res == {}
         d1 = {"a": Decimal("7.175")}
         d2 = {"a": Decimal("7.174")}
         ep = 0.1
-        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        res = DeepDiff(d1, d2, math_epsilon=ep)
         assert res == {}
         d1 = {"a": Decimal("7.175")}
         d2 = {"a": Decimal("7.174")}
         ep = 0.01
-        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        res = DeepDiff(d1, d2, math_epsilon=ep)
         assert res == {}
         d1 = {"a": Decimal("7.175")}
         d2 = {"a": Decimal("7.174")}
         ep = 0.001
-        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        res = DeepDiff(d1, d2, math_epsilon=ep)
         assert res == {}
         d1 = {"a": Decimal("7.175")}
         d2 = {"a": Decimal("7.174")}
@@ -47,7 +47,7 @@ class TestDiffMath:
                 }
             }
         }
-        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        res = DeepDiff(d1, d2, math_epsilon=ep)
         assert res == expected
 
     def test_math_diff_special_case(self):
@@ -57,27 +57,27 @@ class TestDiffMath:
         d1 = {"a": Decimal("9.709999618320632")}
         d2 = {"a": Decimal("9.710000038146973")}
         ep = 0.001
-        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        res = DeepDiff(d1, d2, math_epsilon=ep)
         assert res == {}
         d1 = {"a": Decimal("9.709999618320632")}
         d2 = {"a": Decimal("9.710000038146973")}
         ep = 0.0001
-        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        res = DeepDiff(d1, d2, math_epsilon=ep)
         assert res == {}
         d1 = {"a": Decimal("9.709999618320632")}
         d2 = {"a": Decimal("9.710000038146973")}
         ep = 0.00001
-        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        res = DeepDiff(d1, d2, math_epsilon=ep)
         assert res == {}
         d1 = {"a": Decimal("9.709999618320632")}
         d2 = {"a": Decimal("9.710000038146973")}
         ep = 0.000001
-        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        res = DeepDiff(d1, d2, math_epsilon=ep)
         assert res == {}
         d1 = {"a": Decimal("9.709999618320632")}
         d2 = {"a": Decimal("9.710000038146973")}
         ep = 0.0000001
-        res = DeepDiff(d1, d2, math_close=True, epsilon=ep)
+        res = DeepDiff(d1, d2, math_epsilon=ep)
         expected = {
             "values_changed": {
                 "root['a']": {
@@ -95,13 +95,19 @@ class TestDiffMath:
         d1 = {"a": [Decimal("9.709999618320632"), Decimal("9.709999618320632")]}
         d2 = {"a": [Decimal("9.710000038146973"), Decimal("9.709999618320632")]}
         ep = 0.0001
-        res = DeepDiff(d1, d2, ignore_order=False, math_close=True, epsilon=ep)
+        res = DeepDiff(d1, d2, ignore_order=False, math_epsilon=ep)
         assert res == {}
+
+    def test_math_diff_ignore_order_warning(self, caplog):
+        """math_close will not work with ignore_order=true.
+        
+        Items are hashed if order is ignored, that will not work."""
         d1 = {"a": [Decimal("9.709999618320632"), Decimal("9.709999618320632")]}
         d2 = {"a": [Decimal("9.710000038146973"), Decimal("9.709999618320632")]}
         ep = 0.0001
-        res = DeepDiff(d1, d2, ignore_order=True, math_close=True, epsilon=ep)
+        res = DeepDiff(d1, d2, ignore_order=True, math_epsilon=ep)
         expected = {
             "iterable_item_added": {"root['a'][0]": Decimal("9.710000038146973")}
         }
         assert res == expected
+        assert "math_epsilon will be ignored." in caplog.text

--- a/tests/test_diff_math.py
+++ b/tests/test_diff_math.py
@@ -110,4 +110,4 @@ class TestDiffMath:
             "iterable_item_added": {"root['a'][0]": Decimal("9.710000038146973")}
         }
         assert res == expected
-        assert "math_epsilon will be ignored." in caplog.text
+        # assert "math_epsilon will be ignored." in caplog.text


### PR DESCRIPTION
Hi!

thanks for an awesome library!

I've been using a patch for a few months now, that I wanted to send upstream, as I think others might find it useful.

**Use case**:
For some sensor data derived and computed values must lie in a certain range. It does not matter that they are off by e.g. 1e-5.

To check against that the `math` core module provides the valuable `isclose()` function. It evaluates the being close of two numbers to each other, with reference to an epsilon (abs_tol). This is superior to the format function, as it evaluates the mathematical representation and not the string representation.

**New introduced feature**:
My current implementation works well to compare numbers in objects. As the number is used by `math`, it cannot currently handle the hashing of values, which is done when `ignore_order` is used. Other than that it is solid, as only `math.isclose()` is called.

~~I introduce the `math_close` boolean parameter. If set to True it will use `math.isclose()` to evaluate numbers. The new optional `epsilon` takes a tolerance value which is passed to `math.isclose()`. Any numbers that are within the tolerance will not report as being different. Any numbers outside of that tolerance will show up as different.~~

I introduce the `math_epsilon` parameter. If set will use `math.isclose()` to evaluate numbers. It defines a tolerance value which is passed to `math.isclose()`. Any numbers that are within the tolerance will not report as being different. Any numbers outside of that tolerance will show up as different.

I also added tests for this functionality.