### PR TITLE
Fix .yml not being recognized by deep CLI

### DIFF
--- a/deepdiff/serialization.py
+++ b/deepdiff/serialization.py
@@ -364,7 +364,7 @@ def load_path_content(path, file_type=None):
     if file_type == 'json':
         with open(path, 'r') as the_file:
             content = json.load(the_file)
-    elif file_type in {'yaml', '.yml'}:
+    elif file_type in {'yaml', 'yml'}:
         if yaml is None:  # pragma: no cover.
             raise ImportError('Pyyaml needs to be installed.')  # pragma: no cover.
         with open(path, 'r') as the_file:
@@ -426,7 +426,7 @@ def _save_content(content, path, file_type, keep_backup=True):
     if file_type == 'json':
         with open(path, 'w') as the_file:
             content = json.dump(content, the_file)
-    elif file_type in {'yaml', '.yml'}:
+    elif file_type in {'yaml', 'yml'}:
         if yaml is None:  # pragma: no cover.
             raise ImportError('Pyyaml needs to be installed.')  # pragma: no cover.
         with open(path, 'w') as the_file:


### PR DESCRIPTION
Noticed this while using the CLI; there's a minor typo in the YAML file extension handling.

Before:
```
$ deep diff foo.yml bar.yml 
Error when loading t1: Only json, yaml, toml, csv, tsv and pickle are supported.
 The yml extension is not known.
```

After:
(works as expected)

Thanks for making this tool available, you just saved me from writing something way less useful myself :)