### PR TITLE
Retain the order of multiple dictionary items added via Delta

### DIFF
--- a/deepdiff/delta.py
+++ b/deepdiff/delta.py
@@ -267,16 +267,23 @@ class Delta:
     def _do_dictionary_item_added(self):
         dictionary_item_added = self.diff.get('dictionary_item_added')
         if dictionary_item_added:
-            self._do_item_added(dictionary_item_added)
+            self._do_item_added(dictionary_item_added, sort=False)
 
     def _do_attribute_added(self):
         attribute_added = self.diff.get('attribute_added')
         if attribute_added:
             self._do_item_added(attribute_added)
 
-    def _do_item_added(self, items):
-        # sorting the items by their path so that the items with smaller index are applied first.
-        for path, new_value in sorted(items.items(), key=lambda x: x[0]):
+    def _do_item_added(self, items, sort=True):
+        if sort:
+            # sorting items by their path so that the items with smaller index
+            # are applied first (unless `sort` is `False` so that order of
+            # added items is retained, e.g. for dicts).
+            items = sorted(items.items(), key=lambda x: x[0])
+        else:
+            items = items.items()
+
+        for path, new_value in items:
             elem_and_details = self._get_elements_and_details(path)
             if elem_and_details:
                 elements, parent, parent_to_obj_elem, parent_to_obj_action, obj, elem, action = elem_and_details

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -450,16 +450,16 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
             rel_class = DictRelationship
 
         if self.ignore_private_variables:
-            t1_keys = {key for key in t1 if not(isinstance(key, str) and key.startswith('__'))}
-            t2_keys = {key for key in t2 if not(isinstance(key, str) and key.startswith('__'))}
+            t1_keys = OrderedSet([key for key in t1 if not(isinstance(key, str) and key.startswith('__'))])
+            t2_keys = OrderedSet([key for key in t2 if not(isinstance(key, str) and key.startswith('__'))])
         else:
-            t1_keys = set(t1.keys())
-            t2_keys = set(t2.keys())
+            t1_keys = OrderedSet(t1.keys())
+            t2_keys = OrderedSet(t2.keys())
         if self.ignore_string_type_changes or self.ignore_numeric_type_changes:
             t1_clean_to_keys = self._get_clean_to_keys_mapping(keys=t1_keys, level=level)
             t2_clean_to_keys = self._get_clean_to_keys_mapping(keys=t2_keys, level=level)
-            t1_keys = set(t1_clean_to_keys.keys())
-            t2_keys = set(t2_clean_to_keys.keys())
+            t1_keys = OrderedSet(t1_clean_to_keys.keys())
+            t2_keys = OrderedSet(t2_clean_to_keys.keys())
         else:
             t1_clean_to_keys = t2_clean_to_keys = None
 

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -335,6 +335,41 @@ class TestBasicsOfDelta:
         delta2 = Delta(diff, verify_symmetry=False, raise_errors=True)
         assert t1 + delta2 == t2
 
+    def test_delta_dict_items_added_retain_order(self):
+        t1 = {
+            6: 6
+        }
+
+        t2 = {
+            6: 6,
+            7: 7,
+            3: 3,
+            5: 5,
+            2: 2,
+            4: 4
+        }
+
+        expected_delta_dict = {
+            'dictionary_item_added': {
+                'root[7]': 7,
+                'root[3]': 3,
+                'root[5]': 5,
+                'root[2]': 2,
+                'root[4]': 4
+            }
+        }
+
+        diff = DeepDiff(t1, t2)
+        delta_dict = diff._to_delta_dict()
+        assert expected_delta_dict == delta_dict
+        delta = Delta(diff, verify_symmetry=False, raise_errors=True)
+
+        result = t1 + delta
+        assert result == t2
+
+        assert list(result.keys()) == [6, 7, 3, 5, 2, 4]
+        assert list(result.keys()) == list(t2.keys())
+
 
 picklalbe_obj_without_item = PicklableClass(11)
 del picklalbe_obj_without_item.item


### PR DESCRIPTION
This change allows for the retention of insertion order when multiple dictionary items are added via a `Delta`.

_**Note:** this change only accounts for retaining the order for `dictionary_item_added` since the keys, when sorted via `Delta::_do_item_added`, may end up being arbitrarily re-ordered prior to applying them to the resulting data set. I use the word "arbitrarily" here as the order of a given added key does not affect the addition of any other key to the dictionary._

Example:

```python
from deepdiff import Delta, DeepDiff


t1 = {
    'pears': 2
}

t2 = {
    'pears': 2,
    'cucumbers': 2,
    'bananas': 3,
    'pumpkins': 4,
    'apples': 5
}

diff = DeepDiff(t1, t2)

delta = Delta(diff)

result = {'oranges': 1} + delta
```

In certain situations, it may be desired to retain the original order of the items added to the `t2` data set when applying the `Delta`. The expected result would be the following:

```python
{
    'oranges': 1,
    'cucumbers': 2,
    'bananas': 3,
    'pumpkins': 4,
    'apples': 5
}
```

_**Note:** Please let me know if the unit test does not conform to the existing ones and I can update, if necessary._