### PR TITLE
fix: verbose_level==0 should disable values_changes

### DIFF
--- a/deepdiff/model.py
+++ b/deepdiff/model.py
@@ -182,7 +182,7 @@ class TextResult(ResultDict):
                     remap_dict.update(old_value=change.t1, new_value=change.t2)
 
     def _from_tree_value_changed(self, tree):
-        if 'values_changed' in tree:
+        if 'values_changed' in tree and self.verbose_level > 0:
             for change in tree['values_changed']:
                 the_changed = {'new_value': change.t2, 'old_value': change.t1}
                 self['values_changed'][change.path(

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -81,7 +81,7 @@ class TestSerialization:
 
     # These lines are long but make it easier to notice the difference:
     @pytest.mark.parametrize('verbose_level, expected', [
-        (0, {"type_changes": {"root[0]": {"old_type": str, "new_type": int}}, "dictionary_item_added": ["root[1][5]"], "dictionary_item_removed": ["root[1][3]"], "values_changed": {"root[1][1]": {"new_value": 2, "old_value": 1}}, "iterable_item_added": {"root[2]": "d"}}),
+        (0, {"type_changes": {"root[0]": {"old_type": str, "new_type": int}}, "dictionary_item_added": ["root[1][5]"], "dictionary_item_removed": ["root[1][3]"], "iterable_item_added": {"root[2]": "d"}}),
         (1, {"type_changes": {"root[0]": {"old_type": str, "new_type": int, "old_value": "a", "new_value": 10}}, "dictionary_item_added": ["root[1][5]"], "dictionary_item_removed": ["root[1][3]"], "values_changed": {"root[1][1]": {"new_value": 2, "old_value": 1}}, "iterable_item_added": {"root[2]": "d"}}),
         (2, {"type_changes": {"root[0]": {"old_type": str, "new_type": int, "old_value": "a", "new_value": 10}}, "dictionary_item_added": {"root[1][5]": 6}, "dictionary_item_removed": {"root[1][3]": 4}, "values_changed": {"root[1][1]": {"new_value": 2, "old_value": 1}}, "iterable_item_added": {"root[2]": "d"}}),
     ])


### PR DESCRIPTION
https://zepworks.com/deepdiff/5.5.0/ignore_types_or_values.html
`And if you don’t care about the value of items that have changed type, you can set verbose level to 0`