### PR TITLE
added an option for a custom type with a custom comparison function.

### DIFF
--- a/deepdiff/model.py
+++ b/deepdiff/model.py
@@ -22,6 +22,7 @@ REPORT_KEYS = {
     "set_item_removed",
     "set_item_added",
     "repetition_change",
+    "custom",
 }
 
 

--- a/docs/diff_doc.rst
+++ b/docs/diff_doc.rst
@@ -95,6 +95,10 @@ iterable_compare_func:
     :ref:`iterable_compare_func_label`:
     There are times that we want to guide DeepDiff as to what items to compare with other items. In such cases we can pass a iterable_compare_func that takes a function pointer to compare two items. The function takes three parameters (x, y, level) and should return True if it is a match, False if it is not a match or raise CannotCompare if it is unable to compare the two.
 
+custom_comparison:
+    :ref:`iterable_compare_func_label`:
+    This enables us to configure a custom comparison function for a custom type. This input is a dictionary, in which the keys are a custom type, and the values are a function handle. The function takes two parameters (x, y) and should return True if it is a match, False if it is not a match or raise CannotCompare if it is unable to compare the two. The custom types must not be any of the Python standard types, otherwise this will be ignored.
+
 ignore_private_variables: Boolean, default = True
     :ref:`ignore_private_variables_label`
     Whether to exclude the private variables in the calculations or not. It only affects variables that start with double underscores (__).


### PR DESCRIPTION
input is a python dict() in which the keys are custom types and the values are custom function handles which compare (x, y).
tested locally on the data-structures for which I added this features; without this addition the code got choked. with it the comparison works like a charm.