### PR TITLE
Fix unprocessed key error

### DIFF
--- a/deepdiff/deephash.py
+++ b/deepdiff/deephash.py
@@ -13,9 +13,8 @@ from deepdiff.helper import (strings, numbers, times, unprocessed, not_hashed, a
 from deepdiff.base import Base
 logger = logging.getLogger(__name__)
 
-UNPROCESSED_KEY = 'unprocessed'
+UNPROCESSED_KEY = object()
 
-RESERVED_DICT_KEYS = {UNPROCESSED_KEY}
 EMPTY_FROZENSET = frozenset()
 
 INDEX_VS_ATTRIBUTE = ('[%s]', '.%s')
@@ -185,7 +184,7 @@ class DeepHash(Base):
             except KeyError:
                 raise KeyError(HASH_LOOKUP_ERR_MSG.format(obj)) from None
 
-        if isinstance(obj, strings) and obj in RESERVED_DICT_KEYS:
+        if obj is UNPROCESSED_KEY:
             extract_index = None
 
         return result_n_count if extract_index is None else result_n_count[extract_index]
@@ -229,7 +228,7 @@ class DeepHash(Base):
         """
         result = dict_()
         for key, value in self.hashes.items():
-            if key in RESERVED_DICT_KEYS:
+            if key is UNPROCESSED_KEY:
                 result[key] = value
             else:
                 result[key] = value[extract_index]

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -134,7 +134,7 @@ class TestDeepHash:
         t1 = Bad()
 
         result = DeepHash(t1)
-        expected_result = {t1: unprocessed, 'unprocessed': [t1]}
+        expected_result = {t1: unprocessed, UNPROCESSED_KEY: [t1]}
         assert expected_result == result
 
     def test_built_in_hash_not_sensitive_to_bytecode_vs_unicode(self):
@@ -407,7 +407,7 @@ class TestDeepHashPrep:
         t1 = Bad()
 
         result = DeepHashPrep(t1)
-        expected_result = {t1: unprocessed, 'unprocessed': [t1]}
+        expected_result = {t1: unprocessed, UNPROCESSED_KEY: [t1]}
         assert expected_result == result
 
     class Burrito:


### PR DESCRIPTION
If an object contains "unprocessed" string the lib crashes

```python3
>>> from deepdiff import DeepHash
>>> DeepHash('unprocessed')
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "venv/lib/python3.8/site-packages/deepdiff/deephash.py", line 151, in __init__
    self._hash(obj, parent=parent, parents_ids=frozenset({get_id(obj)}))
  File "venv/lib/python3.8/site-packages/deepdiff/deephash.py", line 410, in _hash
    result, counts = self.hashes[obj]
ValueError: not enough values to unpack (expected 2, got 0)
```

I understand that later this key is used to return unprocessed objects, but I think this approach is better because you can always grab unprocessed objects using UNPROCESSED_KEY constant. 