### PR TITLE
Bug-Fix: TypeError in _get_numbers_distance()  when ignore_order = True

### DIFF
--- a/deepdiff/distance.py
+++ b/deepdiff/distance.py
@@ -194,9 +194,9 @@ def _get_numbers_distance(num1, num2, max_=1):
     """
     if num1 == num2:
         return 0
-    if isinstance(num1, float):
+    if not isinstance(num1, float):
         num1 = float(num1)
-    if isinstance(num2, float):
+    if not isinstance(num2, float):
         num2 = float(num2)
     # Since we have a default cutoff of 0.3 distance when
     # getting the pairs of items during the ingore_order=True


### PR DESCRIPTION
For lists comparison when ignore_order is True, TypeError occurs as type(_max) = float it doesn't match with other numbers like Decimal.
The cast should be done when numbers are not 'float' type.
Example: 

```
from decimal import Decimal
from deepdiff import DeepDiff

def test_deep_diff():
    a = {'a': [Decimal(1), Decimal(2), Decimal(3), Decimal(5)]}
    b = {'a': [Decimal(3), Decimal(2), Decimal(1), Decimal(4)]}
    print(DeepDiff(a, b, ignore_order = True, cutoff_distance_for_pairs=1))

def main():
    test_deep_diff()

if __name__ == "__main__":
    main()

```