### PR TITLE
Allow ordered-set version 4.1.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ordered-set==4.0.2
+ordered-set>=4.0.2,<4.2.0


### PR DESCRIPTION
`ordered-set` has a new version (4.1.0) which is published as a Wheel.

Please allow `deepdiif` users to use this new `ordered-set` version.

Thanks.