### PR TITLE
If bytes object not decodable as UTF-8, assume binary

### DIFF
--- a/deepdiff/deephash.py
+++ b/deepdiff/deephash.py
@@ -68,7 +68,10 @@ def prepare_string_for_hashing(obj, ignore_string_type_changes=False, ignore_str
     """
     original_type = obj.__class__.__name__
     if isinstance(obj, bytes):
-        obj = obj.decode('utf-8')
+        try:
+            obj = obj.decode('utf-8')
+        except UnicodeDecodeError:
+            return obj
     if not ignore_string_type_changes:
         obj = KEY_TO_VAL_STR.format(original_type, obj)
     if ignore_string_case:


### PR DESCRIPTION
Proposed solution for seperman/deepdiff#292

This is a fairly naive solution, but it seems to work.

It might make sense to let the caller choose the character encoding, but that's probably outside the scope of this issue.