### PR TITLE
Fix testsuite on 32-bits architectures.

### DIFF
--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import io
 import json
+import sys
 from decimal import Decimal
 from unittest import mock
 from deepdiff import Delta, DeepDiff
@@ -1054,7 +1055,7 @@ DELTA_NUMPY_TEST_CASES = {
                 'root[5]': 10
             },
             '_numpy_paths': {
-                'root': 'int64'
+                'root': np.where((sys.maxsize > 2**32), 'int64', 'int32')
             }
         },
         'expected_result': 't2'


### PR DESCRIPTION
Fixes #302.

I've tested this in both an `amd64` and a `i386` chroot, seems to work :)