### PR TITLE
Ignores group_by on non-root passes

### DIFF
--- a/deepdiff/serialization.py
+++ b/deepdiff/serialization.py
@@ -187,7 +187,7 @@ class SerializationMixin:
         was set to be True in the diff object.
 
         """
-        if self.group_by is not None:
+        if self.is_root and self.group_by is not None:
             raise ValueError(DELTA_ERROR_WHEN_GROUP_BY)
 
         result = DeltaResult(tree_results=self.tree, ignore_order=self.ignore_order)


### PR DESCRIPTION
I really can't speak to the impact this change would have on the community of users or the DeepDiff codebase itself. I know that all our unit tests are passing but they are of course not exhaustive. The unit tests provided in the DeepDiff project perform the same with and without this change (the same 4 tests are failing regardless).

Interested to see what you think.