### PR TITLE
tests: handle difference in Enum hashes with Python 3.11

### DIFF
--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -581,7 +581,10 @@ class TestDeepDiffText:
                 },
             }
         }
-        assert ddiff == result
+        result311 = dict(result)
+        result311['values_changed'] = dict(result['values_changed'])
+        result311['values_changed']['root._sort_order_'] = {'new_value': 1, 'old_value': 0}
+        assert ddiff in (result, result311)
 
     def test_custom_objects_change(self):
         t1 = CustomClass(1)

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -266,7 +266,8 @@ class TestDeepHashPrep:
             A = 1
             B = 2
 
-        assert DeepHashPrep(MyEnum.A)[MyEnum.A] == r'objMyEnum:{str:_name_:str:A;str:_value_:int:1}'
+        expecteds = (r'objMyEnum:{str:_name_:str:A;str:_value_:int:1}', r'objMyEnum:{str:_name_:str:A;str:_sort_order_:int:0;str:_value_:int:1}')
+        assert DeepHashPrep(MyEnum.A)[MyEnum.A] in expecteds
         assert DeepHashPrep(MyEnum.A) == DeepHashPrep(MyEnum(1))
         assert DeepHashPrep(MyEnum.A) != DeepHashPrep(MyEnum.A.name)
         assert DeepHashPrep(MyEnum.A) != DeepHashPrep(MyEnum.A.value)


### PR DESCRIPTION
With Python 3.11, Enum members have a `_sort_order` attribute
that shows up in the hashes. Update the tests to pass if it's
present (but also still if it's not present, so we still
support Python 3.10 and earlier).

Signed-off-by: Adam Williamson <awilliam@redhat.com>