### PR TITLE
tests: Use tmp_path fixture

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,11 @@ include pytest.ini
 include *.py
 recursive-include docs/ *.rst
 recursive-include docs/ *.png
-recursive-include tests *.py
+recursive-include tests *.csv
 recursive-include tests *.json
+recursive-include tests *.pickle
+recursive-include tests *.py
+recursive-include tests *.toml
+recursive-include tests *.yaml
 global-exclude __pycache__
 global-exclude *.py[co]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DeepDiff v 6.2.1
+# DeepDiff v 6.2.2
 
 ![Downloads](https://img.shields.io/pypi/dm/deepdiff.svg?style=flat)
 ![Python Versions](https://img.shields.io/pypi/pyversions/deepdiff.svg?style=flat)
@@ -14,7 +14,7 @@
 
 Tested on Python 3.7+ and PyPy3.
 
-- **[Documentation](https://zepworks.com/deepdiff/6.2.1/)**
+- **[Documentation](https://zepworks.com/deepdiff/6.2.2/)**
 
 ## What is new?
 
@@ -69,13 +69,13 @@ Note: if you want to use DeepDiff via commandline, make sure to run `pip install
 
 DeepDiff gets the difference of 2 objects.
 
-> - Please take a look at the [DeepDiff docs](https://zepworks.com/deepdiff/6.2.1/diff.html)
-> - The full documentation of all modules can be found on <https://zepworks.com/deepdiff/6.2.1/>
+> - Please take a look at the [DeepDiff docs](https://zepworks.com/deepdiff/6.2.2/diff.html)
+> - The full documentation of all modules can be found on <https://zepworks.com/deepdiff/6.2.2/>
 > - Tutorials and posts about DeepDiff can be found on <https://zepworks.com/tags/deepdiff/>
 
 ## A few Examples
 
-> Note: This is just a brief overview of what DeepDiff can do. Please visit <https://zepworks.com/deepdiff/6.2.1/> for full documentation.
+> Note: This is just a brief overview of what DeepDiff can do. Please visit <https://zepworks.com/deepdiff/6.2.2/> for full documentation.
 
 ### List difference ignoring order or duplicates
 
@@ -279,8 +279,8 @@ Example:
 ```
 
 
-> - Please take a look at the [DeepDiff docs](https://zepworks.com/deepdiff/6.2.1/diff.html)
-> - The full documentation can be found on <https://zepworks.com/deepdiff/6.2.1/>
+> - Please take a look at the [DeepDiff docs](https://zepworks.com/deepdiff/6.2.2/diff.html)
+> - The full documentation can be found on <https://zepworks.com/deepdiff/6.2.2/>
 
 
 # Deep Search
@@ -312,8 +312,8 @@ And you can pass all the same kwargs as DeepSearch to grep too:
 {'matched_paths': {"root['somewhere']": 'around'}, 'matched_values': {"root['long']": 'somewhere'}}
 ```
 
-> - Please take a look at the [DeepSearch docs](https://zepworks.com/deepdiff/6.2.1/dsearch.html)
-> - The full documentation can be found on <https://zepworks.com/deepdiff/6.2.1/>
+> - Please take a look at the [DeepSearch docs](https://zepworks.com/deepdiff/6.2.2/dsearch.html)
+> - The full documentation can be found on <https://zepworks.com/deepdiff/6.2.2/>
 
 # Deep Hash
 (New in v4-0-0)
@@ -321,8 +321,8 @@ And you can pass all the same kwargs as DeepSearch to grep too:
 DeepHash is designed to give you hash of ANY python object based on its contents even if the object is not considered hashable!
 DeepHash is supposed to be deterministic in order to make sure 2 objects that contain the same data, produce the same hash.
 
-> - Please take a look at the [DeepHash docs](https://zepworks.com/deepdiff/6.2.1/deephash.html)
-> - The full documentation can be found on <https://zepworks.com/deepdiff/6.2.1/>
+> - Please take a look at the [DeepHash docs](https://zepworks.com/deepdiff/6.2.2/deephash.html)
+> - The full documentation can be found on <https://zepworks.com/deepdiff/6.2.2/>
 
 Let's say you have a dictionary object.
 
@@ -370,8 +370,8 @@ Which you can write as:
 At first it might seem weird why DeepHash(obj)[obj] but remember that DeepHash(obj) is a dictionary of hashes of all other objects that obj contains too.
 
 
-> - Please take a look at the [DeepHash docs](https://zepworks.com/deepdiff/6.2.1/deephash.html)
-> - The full documentation can be found on <https://zepworks.com/deepdiff/6.2.1/>
+> - Please take a look at the [DeepHash docs](https://zepworks.com/deepdiff/6.2.2/deephash.html)
+> - The full documentation can be found on <https://zepworks.com/deepdiff/6.2.2/>
 
 
 # Using DeepDiff in unit tests
@@ -451,11 +451,11 @@ Thank you!
 
 How to cite this library (APA style):
 
-    Dehpour, S. (2022). DeepDiff (Version 6.2.1) [Software]. Available from https://github.com/seperman/deepdiff.
+    Dehpour, S. (2022). DeepDiff (Version 6.2.2) [Software]. Available from https://github.com/seperman/deepdiff.
 
 How to cite this library (Chicago style):
 
-    Dehpour, Sep. 2022. DeepDiff (version 6.2.1).
+    Dehpour, Sep. 2022. DeepDiff (version 6.2.2).
 
 # Authors
 

--- a/deepdiff/__init__.py
+++ b/deepdiff/__init__.py
@@ -1,6 +1,6 @@
 """This module offers the DeepDiff, DeepSearch, grep, Delta and DeepHash classes."""
 # flake8: noqa
-__version__ = '6.2.1'
+__version__ = '6.2.2'
 import logging
 
 if __name__ == '__main__':

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,9 +60,9 @@ author = 'Sep Dehpour'
 # built documents.
 #
 # The short X.Y version.
-version = '6.2.1'
+version = '6.2.2'
 # The full version, including alpha/beta/rc tags.
-release = '6.2.1'
+release = '6.2.2'
 
 load_dotenv(override=True)
 DOC_VERSION = os.environ.get('DOC_VERSION', version)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 
-DeepDiff 6.2.1 documentation!
+DeepDiff 6.2.2 documentation!
 =============================
 
 *****************

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.2.1
+current_version = 6.2.2
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if sys.version_info.major == 2:  # pragma: no cover
 if os.environ.get('USER', '') == 'vagrant':
     del os.link
 
-version = '6.2.1'
+version = '6.2.2'
 
 
 def get_reqs(filename):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -44,8 +44,8 @@ class TestCommands:
         ('t1.pickle', 't2.pickle', {}, 0),
         ('t1.yaml', 't2.yaml', {}, 0),
     ])
-    def test_deeppatch_command(self, t1, t2, args, expected_exit_code):
-        t1_copy_path = f'/tmp/{t1}'
+    def test_deeppatch_command(self, t1, t2, args, expected_exit_code, tmp_path):
+        t1_copy_path = os.path.join(tmp_path, t1)
         t1 = os.path.join(FIXTURES_DIR, t1)
         t2 = os.path.join(FIXTURES_DIR, t2)
         copyfile(t1, t1_copy_path)
@@ -54,7 +54,7 @@ class TestCommands:
         assert delta_pickled.exit_code == expected_exit_code
 
         if expected_exit_code == 0:
-            delta_path = '/tmp/delta.pickle'
+            delta_path = os.path.join(tmp_path, 'delta.pickle')
             with open(delta_path, 'wb') as the_file:
                 the_file.write(delta_pickled.stdout_bytes)
 

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -84,35 +84,35 @@ class TestBasicsOfDelta:
 
         assert t1 + delta1 + delta2 == t3
 
-    def test_delta_dump_and_read1(self):
+    def test_delta_dump_and_read1(self, tmp_path):
         t1 = [1, 2]
         t2 = [1, 2, 3, 5]
         diff = DeepDiff(t1, t2)
-        path = '/tmp/delta_test.delta'
+        path = os.path.join(tmp_path, 'delta_test.delta')
         with open(path, 'wb') as the_file:
             Delta(diff).dump(the_file)
         delta = Delta(delta_path=path)
         os.remove(path)
         assert delta + t1 == t2
 
-    def test_delta_dump_and_read2(self):
+    def test_delta_dump_and_read2(self, tmp_path):
         t1 = [1, 2]
         t2 = [1, 2, 3, 5]
         diff = DeepDiff(t1, t2)
         delta_content = Delta(diff).dumps()
-        path = '/tmp/delta_test2.delta'
+        path = os.path.join('tmp_path, delta_test2.delta')
         with open(path, 'wb') as the_file:
             the_file.write(delta_content)
         delta = Delta(delta_path=path)
         os.remove(path)
         assert delta + t1 == t2
 
-    def test_delta_dump_and_read3(self):
+    def test_delta_dump_and_read3(self, tmp_path):
         t1 = [1, 2]
         t2 = [1, 2, 3, 5]
         diff = DeepDiff(t1, t2)
         delta_content = Delta(diff).dumps()
-        path = '/tmp/delta_test2.delta'
+        path = os.path.join('tmp_path, delta_test2.delta')
         with open(path, 'wb') as the_file:
             the_file.write(delta_content)
         with pytest.raises(ValueError) as excinfo:


### PR DESCRIPTION
Using the `tmp_path` pytest fixture fixes permission errors when running tests inside a sandbox,
 https://docs.pytest.org/en/6.2.x/tmpdir.html

```
FAILED test_command.py::TestCommands::test_deeppatch_command[t1.json-t2.json-args0-0] - PermissionError: [Errno 13] Permission denied: '/tmp/t1.json'
FAILED test_command.py::TestCommands::test_deeppatch_command[t1_corrupt.json-t2.json-args1-1] - PermissionError: [Errno 13] Permission denied: '/tmp/t1_corrupt.json'
FAILED test_command.py::TestCommands::test_deeppatch_command[t1.json-t2_json.csv-args2-0] - PermissionError: [Errno 13] Permission denied: '/tmp/t1.json'
FAILED test_command.py::TestCommands::test_deeppatch_command[t2_json.csv-t1.json-args3-0] - PermissionError: [Errno 13] Permission denied: '/tmp/delta.pickle'
FAILED test_command.py::TestCommands::test_deeppatch_command[t1.csv-t2.csv-args4-0] - PermissionError: [Errno 13] Permission denied: '/tmp/delta.pickle'
FAILED test_command.py::TestCommands::test_deeppatch_command[t1.toml-t2.toml-args5-0] - PermissionError: [Errno 13] Permission denied: '/tmp/delta.pickle'
FAILED test_command.py::TestCommands::test_deeppatch_command[t1.pickle-t2.pickle-args6-0] - PermissionError: [Errno 13] Permission denied: '/tmp/delta.pickle'
FAILED test_command.py::TestCommands::test_deeppatch_command[t1.yaml-t2.yaml-args7-0] - PermissionError: [Errno 13] Permission denied: '/tmp/delta.pickle'
```