### PR TITLE
Fixed a corner case where numpy's np.float32 nans are not ignored when using ignore_nan_equality

### DIFF
--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -21,7 +21,7 @@ from deepdiff.helper import (strings, bytes_type, numbers, uuids, times, ListIte
                              convert_item_or_items_into_compiled_regexes_else_none,
                              type_is_subclass_of_type_group, type_in_type_group, get_doc,
                              number_to_string, datetime_normalize, KEY_TO_VAL_STR, booleans,
-                             np_ndarray, get_numpy_ndarray_rows, OrderedSetPlus, RepeatedTimer,
+                             np_ndarray, np_floating, get_numpy_ndarray_rows, OrderedSetPlus, RepeatedTimer,
                              TEXT_VIEW, TREE_VIEW, DELTA_VIEW, detailed__dict__, add_root_to_paths,
                              np, get_truncate_datetime, dict_, CannotCompare, ENUM_INCLUDE_KEYS)
 from deepdiff.serialization import SerializationMixin
@@ -1503,7 +1503,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
                 self._report_result('values_changed', level, local_tree=local_tree)
                 return
 
-        if self.ignore_nan_inequality and isinstance(level.t1, float) and str(level.t1) == str(level.t2) == 'nan':
+        if self.ignore_nan_inequality and isinstance(level.t1, (float, np_floating)) and str(level.t1) == str(level.t2) == 'nan':
             return
 
         if isinstance(level.t1, booleans):

--- a/deepdiff/helper.py
+++ b/deepdiff/helper.py
@@ -39,6 +39,7 @@ except ImportError:  # pragma: no cover. The case without Numpy is tested locall
     np_float32 = np_type  # pragma: no cover.
     np_float64 = np_type  # pragma: no cover.
     np_float_ = np_type  # pragma: no cover.
+    np_floating = np_type  # pragma: no cover.
     np_complex64 = np_type  # pragma: no cover.
     np_complex128 = np_type  # pragma: no cover.
     np_complex_ = np_type  # pragma: no cover.
@@ -60,6 +61,7 @@ else:
     np_float32 = np.float32
     np_float64 = np.float64
     np_float_ = np.float_
+    np_floating = np.floating
     np_complex64 = np.complex64
     np_complex128 = np.complex128
     np_complex_ = np.complex_
@@ -68,7 +70,7 @@ else:
 numpy_numbers = (
     np_int8, np_int16, np_int32, np_int64, np_uint8,
     np_uint16, np_uint32, np_uint64, np_intp, np_uintp,
-    np_float32, np_float64, np_float_, np_complex64,
+    np_float32, np_float64, np_float_, np_floating, np_complex64,
     np_complex128, np_complex_,)
 
 numpy_complex_numbers = (
@@ -336,7 +338,7 @@ def number_to_string(number, significant_digits, number_format_notation="f"):
         using = number_formatting[number_format_notation]
     except KeyError:
         raise ValueError("number_format_notation got invalid value of {}. The valid values are 'f' and 'e'".format(number_format_notation)) from None
-    
+
     if not isinstance(number, numbers):
         return number
     elif isinstance(number, Decimal):

--- a/tests/test_diff_numpy.py
+++ b/tests/test_diff_numpy.py
@@ -105,6 +105,14 @@ NUMPY_CASES = {
             }
         },
     },
+    'numpy_array9_ignore_nan_inequality_float32': {
+        't1': np.array([1, 2, 3, np.nan], np.float32),
+        't2': np.array([1, 2, 4, np.nan], np.float32),
+        'deepdiff_kwargs': {
+            'ignore_nan_inequality': True,
+        },
+        'expected_result': {'values_changed': {'root[2]': {'new_value': 4.0, 'old_value': 3.0}}}
+    },
     'numpy_almost_equal': {
         't1': np.array([1.0, 2.3333333333333]),
         't2': np.array([1.0, 2.33333334]),


### PR DESCRIPTION
This PR fixes the following case:
```python
DeepDiff(np.array([1, 2, 3, np.nan], dtype=np.float32), np.array([1, 2, 4, np.nan], dtype=np.float32), ignore_nan_inequality=True)
# Outputs:
{'values_changed': {'root[2]': {'new_value': 4.0, 'old_value': 3.0},
  'root[3]': {'new_value': nan, 'old_value': nan}}}
```

As you can see, **when there are other differences** and we are using **np.float32** typed arrays, the `np.nan` values are not ignored, despite setting `ignore_nan_inequality=True`.

Notice that in case of the default `np.float64` type, it doesn't happen:
```python
DeepDiff(np.array([1, 2, 3, np.nan]), np.array([1, 2, 4, np.nan]), ignore_nan_inequality=True)
# Outputs:
{'values_changed': {'root[2]': {'new_value': 4.0, 'old_value': 3.0}}}
```

Also, no diffs are observed when there are no other differences:
```python
DeepDiff(np.array([1, 2, 3, np.nan], dtype=np.float32), np.array([1, 2, 3, np.nan], dtype=np.float32), ignore_nan_inequality=True)
# Outputs:
{}
```

So I think I made it clear that this corner case has not been mitigated properly.
This is my first PR, so please tell me if there's anything I can improve...
Thanks!