### PR TITLE
Bugfix deephash nonstandard members

### DIFF
--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -153,6 +153,13 @@ class TestDeepHash:
         assert a_hash == b_hash
 
 
+    def test_re(self):
+        import re
+        a = re.compile("asdf.?")
+        a_hash = DeepHash(a)[a]
+        assert not( a_hash is unprocessed)
+
+
 class TestDeepHashPrep:
     """DeepHashPrep Tests covering object serialization."""
 


### PR DESCRIPTION
compiled regular expressions cannot be hashed, because they don't implement __dict__ or __slots__.  (See Issue #384)
This pull request demonstrates the problem and proposes a modified strategy to obtain the member variables based on the inspect module. 