### PR TITLE
Fix tests dependent on toml

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ flake8==6.0.0
 python-dateutil==2.8.2
 orjson==3.8.3
 wheel==0.38.1
+toml==0.10.2


### PR DESCRIPTION
toml is pulled in by "accident" by coverage, but belongs in requirements, otherwise these test are broken:

```
========================================================================================= FAILURES ==========================================================================================
________________________________________________________________ TestCommands.test_diff_command[t1.toml-t2.toml-10.0.0.2-0] _________________________________________________________________

self = <tests.test_command.TestCommands object at 0x7ff1b600e5b0>, t1 = '/var/tmp/portage/portage/dev-python/deepdiff-6.2.3/work/deepdiff-6.2.3/tests/fixtures/t1.toml'
t2 = '/var/tmp/portage/portage/dev-python/deepdiff-6.2.3/work/deepdiff-6.2.3/tests/fixtures/t2.toml', expected_in_stdout = '10.0.0.2', expected_exit_code = 0

    @pytest.mark.parametrize('t1, t2, expected_in_stdout, expected_exit_code', [
        ('t1.json', 't2.json', "'dictionary_item_added\': [root[0]", 0),
        ('t1_corrupt.json', 't2.json', "Expecting property name enclosed in double quotes", 1),
        ('t1.json', 't2_json.csv', "'old_value\': \'value2\'", 0),
        ('t2_json.csv', 't1.json', "'old_value\': \'value3\'", 0),
        ('t1.csv', 't2.csv', "\'new_value\': \'James\'", 0),
        ('t1.toml', 't2.toml', "10.0.0.2", 0),
        ('t1.pickle', 't2.pickle', "'new_value': 5, 'old_value': 1", 0),
        ('t1.yaml', 't2.yaml', "'new_value': 61, 'old_value': 65", 0),
    ])
    def test_diff_command(self, t1, t2, expected_in_stdout, expected_exit_code):
        t1 = os.path.join(FIXTURES_DIR, t1)
        t2 = os.path.join(FIXTURES_DIR, t2)
        runner = CliRunner()
        result = runner.invoke(diff, [t1, t2])
>       assert result.exit_code == expected_exit_code
E       AssertionError: assert 1 == 0
E        +  where 1 = <Result SystemExit('Error when loading t1: Toml needs to be installed.')>.exit_code

expected_exit_code = 0
expected_in_stdout = '10.0.0.2'
result     = <Result SystemExit('Error when loading t1: Toml needs to be installed.')>
runner     = <click.testing.CliRunner object at 0x7ff1b5e83340>
self       = <tests.test_command.TestCommands object at 0x7ff1b600e5b0>
t1         = '/var/tmp/portage/portage/dev-python/deepdiff-6.2.3/work/deepdiff-6.2.3/tests/fixtures/t1.toml'
t2         = '/var/tmp/portage/portage/dev-python/deepdiff-6.2.3/work/deepdiff-6.2.3/tests/fixtures/t2.toml'

tests/test_command.py:28: AssertionError
_______________________________________________________________ TestCommands.test_deeppatch_command[t1.toml-t2.toml-args5-0] ________________________________________________________________

self = <tests.test_command.TestCommands object at 0x7ff1b600edf0>, t1 = '/var/tmp/portage/portage/dev-python/deepdiff-6.2.3/work/deepdiff-6.2.3/tests/fixtures/t1.toml'
t2 = '/var/tmp/portage/portage/dev-python/deepdiff-6.2.3/work/deepdiff-6.2.3/tests/fixtures/t2.toml', args = {}, expected_exit_code = 0
tmp_path = PosixPath('/var/tmp/portage/portage/dev-python/deepdiff-6.2.3/temp/pytest-of-portage/pytest-0/test_deeppatch_command_t1_toml0')

    @pytest.mark.parametrize('t1, t2, args, expected_exit_code', [
        ('t1.json', 't2.json', {}, 0),
        ('t1_corrupt.json', 't2.json', {}, 1),
        ('t1.json', 't2_json.csv', {}, 0),
        ('t2_json.csv', 't1.json', {}, 0),
        ('t1.csv', 't2.csv', ["--ignore-order", "--report-repetition"], 0),
        ('t1.toml', 't2.toml', {}, 0),
        ('t1.pickle', 't2.pickle', {}, 0),
        ('t1.yaml', 't2.yaml', {}, 0),
    ])
    def test_deeppatch_command(self, t1, t2, args, expected_exit_code, tmp_path):
        t1_copy_path = os.path.join(tmp_path, t1)
        t1 = os.path.join(FIXTURES_DIR, t1)
        t2 = os.path.join(FIXTURES_DIR, t2)
        copyfile(t1, t1_copy_path)
        runner = CliRunner()
        delta_pickled = runner.invoke(diff, [t1, t2, '--create-patch', *args])
>       assert delta_pickled.exit_code == expected_exit_code
E       AssertionError: assert 1 == 0
E        +  where 1 = <Result SystemExit('Error when loading t1: Toml needs to be installed.')>.exit_code

args       = {}
delta_pickled = <Result SystemExit('Error when loading t1: Toml needs to be installed.')>
expected_exit_code = 0
runner     = <click.testing.CliRunner object at 0x7ff1b680a190>
self       = <tests.test_command.TestCommands object at 0x7ff1b600edf0>
t1         = '/var/tmp/portage/portage/dev-python/deepdiff-6.2.3/work/deepdiff-6.2.3/tests/fixtures/t1.toml'
t1_copy_path = '/var/tmp/portage/portage/dev-python/deepdiff-6.2.3/temp/pytest-of-portage/pytest-0/test_deeppatch_command_t1_toml0/t1.toml'
t2         = '/var/tmp/portage/portage/dev-python/deepdiff-6.2.3/work/deepdiff-6.2.3/tests/fixtures/t2.toml'
tmp_path   = PosixPath('/var/tmp/portage/portage/dev-python/deepdiff-6.2.3/temp/pytest-of-portage/pytest-0/test_deeppatch_command_t1_toml0')

tests/test_command.py:54: AssertionError
```