### PR TITLE
Fix identification of datetimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ If you want to improve the performance of DeepDiff with certain functionalities 
 
 Please take a look at the [CHANGELOG](CHANGELOG.md) file.
 
+# Survey
+
+:mega: **Please fill out our [fast 5-question survey](https://forms.gle/E6qXexcgjoKnSzjB8)** so that we can learn how & why you use DeepDiff, and what improvements we should make. Thank you! :dancers:
+
+
 # Contribute
 
 1. Please make your PR against the dev branch

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -15,7 +15,7 @@ from collections.abc import Mapping, Iterable, Sequence
 from collections import defaultdict
 from itertools import zip_longest
 from ordered_set import OrderedSet
-from deepdiff.helper import (strings, bytes_type, numbers, uuids, times, ListItemRemovedOrAdded, notpresent,
+from deepdiff.helper import (strings, bytes_type, numbers, uuids, datetimes, ListItemRemovedOrAdded, notpresent,
                              IndexedHash, unprocessed, add_to_frozen_set, basic_types,
                              convert_item_or_items_into_set_else_none, get_type,
                              convert_item_or_items_into_compiled_regexes_else_none,
@@ -1529,7 +1529,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
         if isinstance(level.t1, strings):
             self._diff_str(level, local_tree=local_tree)
 
-        elif isinstance(level.t1, times):
+        elif isinstance(level.t1, datetimes):
             self._diff_datetimes(level, local_tree=local_tree)
 
         elif isinstance(level.t1, uuids):

--- a/tests/test_diff_datetime.py
+++ b/tests/test_diff_datetime.py
@@ -1,0 +1,75 @@
+from datetime import date, datetime, time
+from deepdiff import DeepDiff
+
+
+class TestDiffDatetime:
+    def test_datetime_diff(self):
+        """Testing for the correct setting and usage of epsilon."""
+        d1 = {"a": datetime(2023, 7, 5, 10, 11, 12)}
+        d2 = {"a": datetime(2023, 7, 5, 10, 11, 12)}
+        res = DeepDiff(d1, d2)
+        assert res == {}
+
+        res = DeepDiff(d1, d2, ignore_numeric_type_changes=True)
+        assert res == {}
+
+        d1 = {"a": datetime(2023, 7, 5, 10, 11, 12)}
+        d2 = {"a": datetime(2023, 7, 5, 11, 11, 12)}
+        res = DeepDiff(d1, d2)
+        expected = {
+            "values_changed": {
+                "root['a']": {
+                    "new_value": datetime(2023, 7, 5, 11, 11, 12),
+                    "old_value": datetime(2023, 7, 5, 10, 11, 12),
+                }
+            }
+        }
+        assert res == expected
+
+
+    def test_date_diff(self):
+        """Testing for the correct setting and usage of epsilon."""
+        d1 = {"a": date(2023, 7, 5)}
+        d2 = {"a": date(2023, 7, 5)}
+        res = DeepDiff(d1, d2)
+        assert res == {}
+
+        # this usage failed in version >=6.0, <=6.3.0
+        res = DeepDiff(d1, d2, ignore_numeric_type_changes=True)
+        assert res == {}
+
+        d1 = {"a": date(2023, 7, 5)}
+        d2 = {"a": date(2023, 7, 6)}
+        res = DeepDiff(d1, d2)
+        expected = {
+            "values_changed": {
+                "root['a']": {
+                    "new_value": date(2023, 7, 6),
+                    "old_value": date(2023, 7, 5),
+                }
+            }
+        }
+        assert res == expected
+
+    def test_time_diff(self):
+        """Testing for the correct setting and usage of epsilon."""
+        d1 = {"a": time(10, 11, 12)}
+        d2 = {"a": time(10, 11, 12)}
+        res = DeepDiff(d1, d2)
+        assert res == {}
+
+        res = DeepDiff(d1, d2, ignore_numeric_type_changes=True)
+        assert res == {}
+
+        d1 = {"a": time(10, 11, 12)}
+        d2 = {"a": time(11, 11, 12)}
+        res = DeepDiff(d1, d2)
+        expected = {
+            "values_changed": {
+                "root['a']": {
+                    "new_value": time(11, 11, 12),
+                    "old_value": time(10, 11, 12),
+                }
+            }
+        }
+        assert res == expected


### PR DESCRIPTION
When determining if a type is a `datetime` type, the `datetime.date` type was omitted which caused `datetime.date` values to be considered a number since `helper.datetimes` are included in `helper.numbers`.

Possibly related issues:
* https://github.com/seperman/deepdiff/issues/346
* https://github.com/seperman/deepdiff/issues/331 