### PR TITLE
Add Ignore List Order Option to DeepHash

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -52,3 +52,9 @@ Authors in order of the timeline of their contributions:
 - [martin-kokos](https://github.com/martin-kokos) for using Pytest's tmp_path fixture instead of /tmp/
 - Håvard Thom [havardthom](https://github.com/havardthom) for adding include_obj_callback and include_obj_callback_strict.
 - [Noam Gottlieb](https://github.com/noamgot) for fixing a corner case where numpy's `np.float32` nans are not ignored when using `ignore_nan_equality`.
+- [maggelus](https://github.com/maggelus) for the bugfix deephash for paths.
+- [maggelus](https://github.com/maggelus) for the bugfix deephash compiled regex.
+- [martin-kokos](https://github.com/martin-kokos) for fixing the tests dependent on toml.
+- [kor4ik](https://github.com/kor4ik) for the bugfix for `include_paths` for nested dictionaries.
+- [martin-kokos](https://github.com/martin-kokos) for using tomli and tomli-w for dealing with tomli files.
+- [Alex Sauer-Budge](https://github.com/amsb) for the bugfix for `datetime.date`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # DeepDiff Change log
 
+- v6-3-1
+    - Bugfix deephash for paths by [maggelus](https://github.com/maggelus)
+    - Bugfix deephash compiled regex [maggelus](https://github.com/maggelus)
+    - Fix tests dependent on toml by [martin-kokos](https://github.com/martin-kokos)
+    - Bugfix for `include_paths` for nested dictionaries by [kor4ik](https://github.com/kor4ik)
+    - Use tomli and tomli-w for dealing with tomli files by [martin-kokos](https://github.com/martin-kokos)
+    - Bugfix for `datetime.date` by [Alex Sauer-Budge](https://github.com/amsb)
 - v6-3-0
     - `PrefixOrSuffixOperator`: This operator will skip strings that are suffix or prefix of each other.
     - `include_obj_callback` and `include_obj_callback_strict` are added by [Håvard Thom](https://github.com/havardthom).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DeepDiff v 6.3.0
+# DeepDiff v 6.3.1
 
 ![Downloads](https://img.shields.io/pypi/dm/deepdiff.svg?style=flat)
 ![Python Versions](https://img.shields.io/pypi/pyversions/deepdiff.svg?style=flat)
@@ -17,7 +17,7 @@
 
 Tested on Python 3.7+ and PyPy3.
 
-- **[Documentation](https://zepworks.com/deepdiff/6.3.0/)**
+- **[Documentation](https://zepworks.com/deepdiff/6.3.1/)**
 
 ## What is new?
 
@@ -93,11 +93,11 @@ Thank you!
 
 How to cite this library (APA style):
 
-    Dehpour, S. (2023). DeepDiff (Version 6.3.0) [Software]. Available from https://github.com/seperman/deepdiff.
+    Dehpour, S. (2023). DeepDiff (Version 6.3.1) [Software]. Available from https://github.com/seperman/deepdiff.
 
 How to cite this library (Chicago style):
 
-    Dehpour, Sep. 2023. DeepDiff (version 6.3.0).
+    Dehpour, Sep. 2023. DeepDiff (version 6.3.1).
 
 # Authors
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ Tested on Python 3.7+ and PyPy3.
 
 Please check the [ChangeLog](CHANGELOG.md) file for the detailed information.
 
+DeepDiff 6-3-1
+
+This release includes many bug fixes.
+
+- Bugfix deephash for paths by [maggelus](https://github.com/maggelus)
+- Bugfix deephash compiled regex [maggelus](https://github.com/maggelus)
+- Fix tests dependent on toml by [martin-kokos](https://github.com/martin-kokos)
+- Bugfix for `include_paths` for nested dictionaries by [kor4ik](https://github.com/kor4ik)
+- Use tomli and tomli-w for dealing with tomli files by [martin-kokos](https://github.com/martin-kokos)
+- Bugfix for `datetime.date` by [Alex Sauer-Budge](https://github.com/amsb)
+
+
 DeepDiff 6-3-0
 
 - [`PrefixOrSuffixOperator`](https://zepworks.com/deepdiff/current/custom.html#prefix-or-suffix-operator-label): This operator will skip strings that are suffix or prefix of each other.
@@ -30,11 +42,6 @@ DeepDiff 6-3-0
 - Fixed a corner case where numpy's `np.float32` nans are not ignored when using `ignore_nan_equality` by [Noam Gottlieb](https://github.com/noamgot)
 - `orjson` becomes optional again.
 - Fix for `ignore_type_in_groups` with numeric values so it does not report number changes when the number types are different.
-
-DeepDiff 6-2-0
-
-- Major improvement in the diff report for lists when items are all hashable and the order of items is important.
-
 
 ## Installation
 

--- a/deepdiff/__init__.py
+++ b/deepdiff/__init__.py
@@ -1,6 +1,6 @@
 """This module offers the DeepDiff, DeepSearch, grep, Delta and DeepHash classes."""
 # flake8: noqa
-__version__ = '6.3.0'
+__version__ = '6.3.1'
 import logging
 
 if __name__ == '__main__':

--- a/deepdiff/deephash.py
+++ b/deepdiff/deephash.py
@@ -426,11 +426,9 @@ class DeepHash(Base):
                 '{}|{}'.format(i, v) for i, v in result.items()
             ]
 
-        print(result)
         result = map(str, result) # making sure the result items are string so join command works.
         if self.ignore_list_order:
             result = sorted(result)  
-        print(result)
         result = ','.join(result)
         result = KEY_TO_VAL_STR.format(type(obj).__name__, result)
 

--- a/deepdiff/deephash.py
+++ b/deepdiff/deephash.py
@@ -144,6 +144,7 @@ class DeepHash(Base):
                  parent="root",
                  encodings=None,
                  ignore_encoding_errors=False,
+                 ignore_list_order=True,
                  **kwargs):
         if kwargs:
             raise ValueError(
@@ -190,6 +191,7 @@ class DeepHash(Base):
         self.ignore_private_variables = ignore_private_variables
         self.encodings = encodings
         self.ignore_encoding_errors = ignore_encoding_errors
+        self.ignore_list_order = ignore_list_order
 
         self._hash(obj, parent=parent, parents_ids=frozenset({get_id(obj)}))
 
@@ -424,7 +426,11 @@ class DeepHash(Base):
                 '{}|{}'.format(i, v) for i, v in result.items()
             ]
 
-        result = sorted(map(str, result))  # making sure the result items are string and sorted so join command works.
+        print(result)
+        result = map(str, result) # making sure the result items are string so join command works.
+        if self.ignore_list_order:
+            result = sorted(result)  
+        print(result)
         result = ','.join(result)
         result = KEY_TO_VAL_STR.format(type(obj).__name__, result)
 

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -71,7 +71,18 @@ Authors in order of the timeline of their contributions:
 -  `Noam Gottlieb <https://github.com/noamgot>`__ for fixing a corner
    case where numpy’s ``np.float32`` nans are not ignored when using
    ``ignore_nan_equality``.
-
+-  `maggelus <https://github.com/maggelus>`__ for the bugfix deephash
+   for paths.
+-  `maggelus <https://github.com/maggelus>`__ for the bugfix deephash
+   compiled regex.
+-  `martin-kokos <https://github.com/martin-kokos>`__ for fixing the
+   tests dependent on toml.
+-  `kor4ik <https://github.com/kor4ik>`__ for the bugfix for
+   ``include_paths`` for nested dictionaries.
+-  `martin-kokos <https://github.com/martin-kokos>`__ for using tomli
+   and tomli-w for dealing with tomli files.
+-  `Alex Sauer-Budge <https://github.com/amsb>`__ for the bugfix for
+   ``datetime.date``.
 
 .. _Sep Dehpour (Seperman): http://www.zepworks.com
 .. _Victor Hahn Castell: http://hahncastell.de

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,21 @@ Changelog
 
 DeepDiff Changelog
 
+-  v6-3-1
+
+   -  Bugfix deephash for paths by
+      `maggelus <https://github.com/maggelus>`__
+   -  Bugfix deephash compiled regex
+      `maggelus <https://github.com/maggelus>`__
+   -  Fix tests dependent on toml by
+      `martin-kokos <https://github.com/martin-kokos>`__
+   -  Bugfix for ``include_paths`` for nested dictionaries by
+      `kor4ik <https://github.com/kor4ik>`__
+   -  Use tomli and tomli-w for dealing with tomli files by
+      `martin-kokos <https://github.com/martin-kokos>`__
+   -  Bugfix for ``datetime.date`` by `Alex
+      Sauer-Budge <https://github.com/amsb>`__
+
 -  v6-3-0
 
    -  ``PrefixOrSuffixOperator``: This operator will skip strings that

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,9 +60,9 @@ author = 'Sep Dehpour'
 # built documents.
 #
 # The short X.Y version.
-version = '6.3.0'
+version = '6.3.1'
 # The full version, including alpha/beta/rc tags.
-release = '6.3.0'
+release = '6.3.1'
 
 load_dotenv(override=True)
 DOC_VERSION = os.environ.get('DOC_VERSION', version)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx_sitemap',
+    'sphinxemoji.sphinxemoji',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -52,7 +53,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'DeepDiff'
-copyright = '2015-2021, Sep Dehpour'
+copyright = '2015-2023, Sep Dehpour'
 author = 'Sep Dehpour'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/diff_doc.rst
+++ b/docs/diff_doc.rst
@@ -6,6 +6,9 @@ DeepDiff
 Deep Difference of dictionaries, iterables, strings and almost any other object.
 It will recursively look for all the changes.
 
+.. Note::
+    |:mega:| **Please fill out our** `fast 5-question survey <https://forms.gle/E6qXexcgjoKnSzjB8>`__ so that we can learn how & why you use DeepDiff, and what improvements we should make. Thank you! |:dancers:|
+
 **Parameters**
 
 t1 : A dictionary, list, string or any python object that has __dict__ or __slots__
@@ -185,3 +188,4 @@ view: string, default = text
 **Supported data types**
 
 int, string, unicode, dictionary, list, tuple, set, frozenset, OrderedDict, NamedTuple, Numpy, custom objects and more!
+

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -3,6 +3,9 @@
 F.A.Q
 =====
 
+.. Note::
+    |:mega:| **Please fill out our** `fast 5-question survey <https://forms.gle/E6qXexcgjoKnSzjB8>`__ so that we can learn how & why you use DeepDiff, and what improvements we should make. Thank you! |:dancers:|
+
 
 Q: DeepDiff report is not precise when ignore_order=True
 --------------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,25 @@ What is New
 ***********
 
 
+DeepDiff 6-3-1
+--------------
+
+This release includes many bug fixes.
+
+-  Bugfix deephash for paths by
+  `maggelus <https://github.com/maggelus>`__
+-  Bugfix deephash compiled regex
+  `maggelus <https://github.com/maggelus>`__
+-  Fix tests dependent on toml by
+  `martin-kokos <https://github.com/martin-kokos>`__
+-  Bugfix for ``include_paths`` for nested dictionaries by
+  `kor4ik <https://github.com/kor4ik>`__
+-  Use tomli and tomli-w for dealing with tomli files by
+  `martin-kokos <https://github.com/martin-kokos>`__
+-  Bugfix for ``datetime.date`` by `Alex
+  Sauer-Budge <https://github.com/amsb>`__
+
+
 DeepDiff 6-3-0
 --------------
 
@@ -44,12 +63,6 @@ DeepDiff 6-3-0
    Gottlieb <https://github.com/noamgot>`__
 -  ``orjson`` becomes optional again.
 -  Fix for ``ignore_type_in_groups`` with numeric values so it does not report number changes when the number types are different.
-
-DeepDiff 6-2-0
---------------
-
--  Major improvement in the diff report for lists when items are all hashable and the order of items is important.
-
 
 *********
 Tutorials

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,18 +37,12 @@ DeepDiff 6-3-1
 
 This release includes many bug fixes.
 
--  Bugfix deephash for paths by
-  `maggelus <https://github.com/maggelus>`__
--  Bugfix deephash compiled regex
-  `maggelus <https://github.com/maggelus>`__
--  Fix tests dependent on toml by
-  `martin-kokos <https://github.com/martin-kokos>`__
--  Bugfix for ``include_paths`` for nested dictionaries by
-  `kor4ik <https://github.com/kor4ik>`__
--  Use tomli and tomli-w for dealing with tomli files by
-  `martin-kokos <https://github.com/martin-kokos>`__
--  Bugfix for ``datetime.date`` by `Alex
-  Sauer-Budge <https://github.com/amsb>`__
+-  Bugfix deephash for paths by `maggelus <https://github.com/maggelus>`__
+-  Bugfix deephash compiled regex `maggelus <https://github.com/maggelus>`__
+-  Fix tests dependent on toml by `martin-kokos <https://github.com/martin-kokos>`__
+-  Bugfix for ``include_paths`` for nested dictionaries by `kor4ik <https://github.com/kor4ik>`__
+-  Use tomli and tomli-w for dealing with tomli files by `martin-kokos <https://github.com/martin-kokos>`__
+-  Bugfix for ``datetime.date`` by `Alex Sauer-Budge <https://github.com/amsb>`__
 
 
 DeepDiff 6-3-0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 
-DeepDiff 6.3.0 documentation!
+DeepDiff 6.3.1 documentation!
 =============================
 
 *******

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -6,9 +6,14 @@ Support
 Hello,
 
 This is Sep, the creator of DeepDiff. Thanks for using DeepDiff!
-If you find a bug please create a ticket on our `github repo`_
+If you find a bug, please create a ticket on our `github repo`_
 
-Please note that my time is very limited for support given my other commitments so it may take a while to get back to you. In case you need direct contact for a pressing issue, I can be reached via hello at zepworks . com email address for consulting.
+Contributions to DeepDiff are always very welcome! More than `50 people </deepdiff/current/authors.html>`__ have contributed code to DeepDiff so far.
+
+I love working on DeepDiff and other open-source projects. These projects will stay free and open source forever. If my work has been helpful to you, I would appreciate any sponsorship. Also, if you have any issue with my code that needs my immediate attention, I will be grateful for donations.
+
+Please `click here <https://github.com/sponsors/seperman>`__ to read
+more about sponsoring my work.
 
 Thank you!
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ python-dotenv==0.21.0
 watchdog==2.2.0
 Sphinx==5.3.0
 sphinx-sitemap==2.2.1
+sphinxemoji==0.2.0
 flake8==6.0.0
 python-dateutil==2.8.2
 orjson==3.8.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.3.0
+current_version = 6.3.1
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if sys.version_info.major == 2:  # pragma: no cover
 if os.environ.get('USER', '') == 'vagrant':
     del os.link
 
-version = '6.3.0'
+version = '6.3.1'
 
 
 def get_reqs(filename):

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -382,8 +382,6 @@ class TestDeepHashPrep:
         list1_hash = DeepHash(list1, ignore_list_order=ignore_list_order)
         list2_hash = DeepHash(list2, ignore_list_order=ignore_list_order)
         
-        print(list2_hash)
-        
         assert is_equal == (list1_hash[list1] == list2_hash[list2])
 
     @pytest.mark.parametrize("t1, t2, significant_digits, number_format_notation, result", [

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -368,6 +368,23 @@ class TestDeepHashPrep:
         t2_hash = DeepHashPrep(t2)
 
         assert t1_hash[get_id(t1)] == t2_hash[get_id(t2)]
+        
+    @pytest.mark.parametrize("list1, list2, ignore_list_order, is_equal", [
+        ([1, 2], [2, 1], False, False),
+        ([1, 2], [2, 1], True, True),
+        ([1, 2, 3], [1, 3, 2], False, False),
+        ([1, [1, 2, 3]], [1, [3, 2, 1]], False, False),
+        ([1, [1, 2, 3]], [1, [3, 2, 1]], True, True),
+        ((1, 2), (2, 1), False, False),
+        ((1, 2), (2, 1), True, True),
+    ])
+    def test_list_ignore_order(self, list1, list2, ignore_list_order, is_equal):
+        list1_hash = DeepHash(list1, ignore_list_order=ignore_list_order)
+        list2_hash = DeepHash(list2, ignore_list_order=ignore_list_order)
+        
+        print(list2_hash)
+        
+        assert is_equal == (list1_hash[list1] == list2_hash[list2])
 
     @pytest.mark.parametrize("t1, t2, significant_digits, number_format_notation, result", [
         ({0.012, 0.98}, {0.013, 0.99}, 1, "f", 'set:float:0.0,float:1.0'),


### PR DESCRIPTION
This changes adds a new `ignore_list_order` option to the `DeepHash` class that allows users to specify whether lists should be sorted or not prior to the hash being computed. By default the option is set to `True` which preserves existing behavior. 

A new test (`test_list_ignore_order`) for this option as been added to `tests/test_hash.py`.

This also addresses https://github.com/seperman/deepdiff/issues/361