### PR TITLE
pyyaml to 6.0.1 to fix cython build problems

### DIFF
--- a/requirements-cli.txt
+++ b/requirements-cli.txt
@@ -1,2 +1,2 @@
 click==8.1.3
-pyyaml==6.0
+pyyaml==6.0.1


### PR DESCRIPTION
This bumps pyyaml to 6.0.1 to resolve build issues related to cython 3.0 release.

See:
yaml/pyyaml#601
yaml/pyyaml#702