### PR TITLE
Fixes for NumPy 2.0 compatiblity

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,13 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         architecture: ["x64"]
+        include:
+          - python-version: 3.9
+            numpy-version: "2.0.dev"
+          - python-version: 3.10
+            numpy-version: "2.0.dev"
+          - python-version: 3.11
+            numpy-version: "2.0.dev"
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }} on ${{ matrix.architecture }}
@@ -37,6 +44,9 @@ jobs:
     - name: Install dependencies
       if: matrix.python-version != 3.7
       run: pip install -r requirements-dev.txt
+    - name: Install Numpy Dev
+      if: ${{ matrix.numpy-version }}
+      run: pip install -I --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple "numpy>=0.0.dev0" 
     - name: Lint with flake8
       if: matrix.python-version == 3.11
       run: |

--- a/deepdiff/helper.py
+++ b/deepdiff/helper.py
@@ -64,11 +64,11 @@ else:
     np_uintp = np.uintp
     np_float32 = np.float32
     np_float64 = np.float64
-    np_float_ = np.float_
+    np_float_ = np.double  # np.float_ is an alias for np.double and is being removed by NumPy 2.0
     np_floating = np.floating
     np_complex64 = np.complex64
     np_complex128 = np.complex128
-    np_complex_ = np.complex_
+    np_complex_ = np.cdouble # np.complex_ is an alias for np.cdouble and is being removed by NumPy 2.0
     np_complexfloating = np.complexfloating
 
 numpy_numbers = (

--- a/deepdiff/helper.py
+++ b/deepdiff/helper.py
@@ -655,7 +655,7 @@ def diff_numpy_array(A, B):
     By Divakar
     https://stackoverflow.com/a/52417967/1497443
     """
-    return A[~np.in1d(A, B)]
+    return A[~np.isin(A, B)]
 
 
 PYTHON_TYPE_TO_NUMPY_TYPE = {


### PR DESCRIPTION
NumPy 2.0 has removed a couple of type aliases referenced by `deepdiff` as part of [NEP 52](https://numpy.org/neps/nep-0052-python-api-cleanup.html) in numpy/numpy#24376. Namely,

- `np.float_`, which is an alias of `np.double` according to the [NumPy docs](https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.float_).
- `np.complex_`, which is an alias of `np.cdouble` according to the [NumPy docs](https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.complex_).

These are blocking my ability to test code using NumPy 2.0 (see spacetelescope/romancal#886).

When I ran the test suite with NumPy 2.0 installed there was one additional deprecation of `np.in1d` in favor or `np.isin`.

In any case, the `deepdiff` tests pass locally for me if I install the published dev wheel of NumPy via:
```shell
pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple "numpy>=0.0.dev0
```
to override the current `requirements-dev.txt` [pin](https://github.com/seperman/deepdiff/blob/450634aefe1b499398f3fa7a1368edd7873fa0a7/requirements-dev.txt#L7) for NumPy.  I have not touched the GitHub CI for `deepdiff` in order to run NumPy 2.0 tests at this time, please let me know if/how you would like me to do this if you would like that added.