### PR TITLE
6.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # DeepDiff Change log
 
+- v6-7-0
+    - Delta can be subtracted from other objects now.
+    - verify_symmetry is deprecated. Use bidirectional instead.
+    - always_include_values flag in Delta can be enabled to include values in the delta for every change.
+    - Fix for Delta.__add__ breaks with esoteric dict keys.
+    - You can load a delta from the list of flat dictionaries.
 - v6-6-1
     - Fix for [DeepDiff raises decimal exception when using significant digits](https://github.com/seperman/deepdiff/issues/426)
     - Introducing group_by_sort_key

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DeepDiff v 6.6.1
+# DeepDiff v 6.7.0
 
 ![Downloads](https://img.shields.io/pypi/dm/deepdiff.svg?style=flat)
 ![Python Versions](https://img.shields.io/pypi/pyversions/deepdiff.svg?style=flat)
@@ -17,7 +17,7 @@
 
 Tested on Python 3.7+ and PyPy3.
 
-- **[Documentation](https://zepworks.com/deepdiff/6.6.1/)**
+- **[Documentation](https://zepworks.com/deepdiff/6.7.0/)**
 
 ## What is new?
 
@@ -98,11 +98,11 @@ Thank you!
 
 How to cite this library (APA style):
 
-    Dehpour, S. (2023). DeepDiff (Version 6.6.1) [Software]. Available from https://github.com/seperman/deepdiff.
+    Dehpour, S. (2023). DeepDiff (Version 6.7.0) [Software]. Available from https://github.com/seperman/deepdiff.
 
 How to cite this library (Chicago style):
 
-    Dehpour, Sep. 2023. DeepDiff (version 6.6.1).
+    Dehpour, Sep. 2023. DeepDiff (version 6.7.0).
 
 # Authors
 

--- a/README.md
+++ b/README.md
@@ -23,28 +23,19 @@ Tested on Python 3.7+ and PyPy3.
 
 Please check the [ChangeLog](CHANGELOG.md) file for the detailed information.
 
+DeepDiff v6-7-0
+
+- Delta can be subtracted from other objects now.
+- verify_symmetry is deprecated. Use bidirectional instead.
+- always_include_values flag in Delta can be enabled to include values in the delta for every change.
+- Fix for Delta.__add__ breaks with esoteric dict keys.
+- You can load a delta from the list of flat dictionaries.
+
 DeepDiff 6-6-1
+
 - Fix for [DeepDiff raises decimal exception when using significant digits](https://github.com/seperman/deepdiff/issues/426)
 - Introducing group_by_sort_key
 - Adding group_by 2D. For example `group_by=['last_name', 'zip_code']`
-
-
-DeepDiff 6-6-0
-
-- [Serialize To Flat Dicts](https://zepworks.com/deepdiff/current/serialization.html#delta-to-flat-dicts-label)
-- [NumPy 2.0 compatibility](https://github.com/seperman/deepdiff/pull/422) by [William Jamieson](https://github.com/WilliamJamieson)
-
-DeepDiff 6-5-0
-
-- [parse_path](https://zepworks.com/deepdiff/current/faq.html#q-how-do-i-parse-deepdiff-result-paths)
-
-DeepDiff 6-4-1
-
-- [Add Ignore List Order Option to DeepHash](https://github.com/seperman/deepdiff/pull/403) by 
-[Bobby Morck](https://github.com/bmorck)
-- [pyyaml to 6.0.1 to fix cython build problems](https://github.com/seperman/deepdiff/pull/406) by [Robert Bo Davis](https://github.com/robert-bo-davis)
-- [Precompiled regex simple diff](https://github.com/seperman/deepdiff/pull/413) by [cohml](https://github.com/cohml)
-- New flag: `zip_ordered_iterables` for forcing iterable items to be compared one by one. 
 
 
 ## Installation

--- a/deepdiff/__init__.py
+++ b/deepdiff/__init__.py
@@ -1,6 +1,6 @@
 """This module offers the DeepDiff, DeepSearch, grep, Delta and DeepHash classes."""
 # flake8: noqa
-__version__ = '6.6.1'
+__version__ = '6.7.0'
 import logging
 
 if __name__ == '__main__':

--- a/deepdiff/delta.py
+++ b/deepdiff/delta.py
@@ -623,6 +623,7 @@ class Delta:
         include_action_in_path : Boolean, default=False
             When False, we translate DeepDiff's paths like root[3].attribute1 into a [3, 'attribute1'].
             When True, we include the action to retrieve the item in the path: [(3, 'GET'), ('attribute1', 'GETATTR')]
+            Note that the "action" here is the different than the action reported by to_flat_dicts. The action here is just about the "path" output.
 
         report_type_changes : Boolean, default=True
             If False, we don't report the type change. Instead we report the value change.

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -493,9 +493,8 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
         elif self.include_obj_callback_strict and level_path != 'root':
             skip = True
             if (self.include_obj_callback_strict(level.t1, level_path) and
-                self.include_obj_callback_strict(level.t2, level_path)):
+                    self.include_obj_callback_strict(level.t2, level_path)):
                 skip = False
-
 
         return skip
 

--- a/deepdiff/model.py
+++ b/deepdiff/model.py
@@ -874,7 +874,21 @@ class ChildRelationship:
         """
         param = self.param
         if isinstance(param, strings):
-            result = param if self.quote_str is None else self.quote_str.format(param)
+            has_quote = "'" in param
+            has_double_quote = '"' in param
+            if has_quote and has_double_quote:
+                new_param = []
+                for char in param:
+                    if char in {'"', "'"}:
+                        new_param.append('\\')
+                    new_param.append(char)
+                param = ''.join(new_param)
+            elif has_quote:
+                result = f'"{param}"'
+            elif has_double_quote:
+                result = f"'{param}'"
+            else:
+                result = param if self.quote_str is None else self.quote_str.format(param)
         elif isinstance(param, tuple):  # Currently only for numpy ndarrays
             result = ']['.join(map(repr, param))
         else:

--- a/deepdiff/model.py
+++ b/deepdiff/model.py
@@ -279,8 +279,9 @@ class TextResult(ResultDict):
 class DeltaResult(TextResult):
     ADD_QUOTES_TO_STRINGS = False
 
-    def __init__(self, tree_results=None, ignore_order=None):
+    def __init__(self, tree_results=None, ignore_order=None, always_include_values=False):
         self.ignore_order = ignore_order
+        self.always_include_values = always_include_values
 
         self.update({
             "type_changes": dict_(),
@@ -375,7 +376,7 @@ class DeltaResult(TextResult):
                 })
                 self['type_changes'][change.path(
                     force=FORCE_DEFAULT)] = remap_dict
-                if include_values:
+                if include_values or self.always_include_values:
                     remap_dict.update(old_value=change.t1, new_value=change.t2)
 
     def _from_tree_value_changed(self, tree):

--- a/deepdiff/model.py
+++ b/deepdiff/model.py
@@ -5,6 +5,7 @@ from ordered_set import OrderedSet
 from deepdiff.helper import (
     RemapDict, strings, short_repr, notpresent, get_type, numpy_numbers, np, literal_eval_extended,
     dict_)
+from deepdiff.path import stringify_element
 
 logger = logging.getLogger(__name__)
 
@@ -874,21 +875,7 @@ class ChildRelationship:
         """
         param = self.param
         if isinstance(param, strings):
-            has_quote = "'" in param
-            has_double_quote = '"' in param
-            if has_quote and has_double_quote:
-                new_param = []
-                for char in param:
-                    if char in {'"', "'"}:
-                        new_param.append('\\')
-                    new_param.append(char)
-                param = ''.join(new_param)
-            elif has_quote:
-                result = f'"{param}"'
-            elif has_double_quote:
-                result = f"'{param}'"
-            else:
-                result = param if self.quote_str is None else self.quote_str.format(param)
+            result = stringify_element(param, quote_str=self.quote_str)
         elif isinstance(param, tuple):  # Currently only for numpy ndarrays
             result = ']['.join(map(repr, param))
         else:

--- a/deepdiff/path.py
+++ b/deepdiff/path.py
@@ -53,15 +53,21 @@ def _path_to_elements(path, root_element=DEFAULT_FIRST_ELEMENT):
     path = path[4:]  # removing "root from the beginning"
     brackets = []
     inside_quotes = False
+    quote_used = ''
     for char in path:
         if prev_char == '\\':
             elem += char
         elif char in {'"', "'"}:
             elem += char
-            inside_quotes = not inside_quotes
-            if not inside_quotes:
-                _add_to_elements(elements, elem, inside)
-                elem = ''
+            # If we are inside and the quote is not what we expected, the quote is not closing
+            if not(inside_quotes and quote_used != char):
+                inside_quotes = not inside_quotes
+                if inside_quotes:
+                    quote_used = char
+                else:
+                    _add_to_elements(elements, elem, inside)
+                    elem = ''
+                    quote_used = ''
         elif inside_quotes:
             elem += char
         elif char == '[':

--- a/deepdiff/serialization.py
+++ b/deepdiff/serialization.py
@@ -215,7 +215,7 @@ class SerializationMixin:
         view = view_override if view_override else self.view
         return dict(self._get_view_results(view))
 
-    def _to_delta_dict(self, directed=True, report_repetition_required=True):
+    def _to_delta_dict(self, directed=True, report_repetition_required=True, always_include_values=False):
         """
         Dump to a dictionary suitable for delta usage.
         Unlike to_dict, this is not dependent on the original view that the user chose to create the diff.
@@ -241,7 +241,7 @@ class SerializationMixin:
         if self.group_by is not None:
             raise ValueError(DELTA_ERROR_WHEN_GROUP_BY)
 
-        result = DeltaResult(tree_results=self.tree, ignore_order=self.ignore_order)
+        result = DeltaResult(tree_results=self.tree, ignore_order=self.ignore_order, always_include_values=always_include_values)
         result.remove_empty_keys()
         if report_repetition_required and self.ignore_order and not self.report_repetition:
             raise ValueError(DELTA_IGNORE_ORDER_NEEDS_REPETITION_REPORT)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,14 @@ Changelog
 
 DeepDiff Changelog
 
+-  v6-7-0
+
+   -  Delta can be subtracted from other objects now.
+   -  verify_symmetry is deprecated. Use bidirectional instead.
+   -  always_include_values flag in Delta can be enabled to include
+      values in the delta for every change.
+   -  Fix for Delta.\__add\_\_ breaks with esoteric dict keys.
+
 -  v6-6-1
 
     -  Fix for `DeepDiff raises decimal exception when using significant

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,9 +61,9 @@ author = 'Sep Dehpour'
 # built documents.
 #
 # The short X.Y version.
-version = '6.6.1'
+version = '6.7.0'
 # The full version, including alpha/beta/rc tags.
-release = '6.6.1'
+release = '6.7.0'
 
 load_dotenv(override=True)
 DOC_VERSION = os.environ.get('DOC_VERSION', version)

--- a/docs/custom.rst
+++ b/docs/custom.rst
@@ -183,7 +183,7 @@ To define an custom operator, you just need to inherit a *BaseOperator* and
     * implement a give_up_diffing method
         * give_up_diffing(level: DiffLevel, diff_instance: DeepDiff) -> boolean
 
-          If it returns True, then we will give up diffing the tow objects.
+          If it returns True, then we will give up diffing the two objects.
           You may or may not use the diff_instance.custom_report_result within this function
           to report any diff. If you decide not to report anything, and this
           function returns True, then the objects are basically skipped in the results.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,18 @@ The DeepDiff library includes the following modules:
 What Is New
 ***********
 
+
+DeepDiff 6-7-0
+--------------
+
+    -  Delta can be subtracted from other objects now.
+    -  verify_symmetry is deprecated. Use bidirectional instead.
+    -  :ref:`always_include_values_label` flag in Delta can be enabled to include
+       values in the delta for every change.
+    -  Fix for Delta.\__add\_\_ breaks with esoteric dict keys.
+    -  :ref:`delta_from_flat_dicts_label` can be used to load a delta from the list of flat dictionaries.
+
+
 DeepDiff 6-6-1
 --------------
 
@@ -45,26 +57,6 @@ DeepDiff 6-6-0
     
     - :ref:`delta_to_flat_dicts_label` can be used to serialize delta objects into a flat list of dictionaries.
     - `NumPy 2.0 compatibility <https://github.com/seperman/deepdiff/pull/422>`__ by `William Jamieson <https://github.com/WilliamJamieson>`__
-
-DeepDiff 6-5-0
---------------
-
-    -  `parse_path <https://zepworks.com/deepdiff/current/faq.html#q-how-do-i-parse-deepdiff-result-paths>`__
-
-DeepDiff 6-4-0
---------------
-
-   -  `Add Ignore List Order Option to
-      DeepHash <https://github.com/seperman/deepdiff/pull/403>`__ by
-      `Bobby Morck <https://github.com/bmorck>`__
-   -  `pyyaml to 6.0.1 to fix cython build
-      problems <https://github.com/seperman/deepdiff/pull/406>`__ by
-      `Robert Bo Davis <https://github.com/robert-bo-davis>`__
-   -  `Precompiled regex simple
-      diff <https://github.com/seperman/deepdiff/pull/413>`__ by
-      `cohml <https://github.com/cohml>`__
-   -  New flag: ``zip_ordered_iterables`` for forcing iterable items to
-      be compared one by one.
 
 
 *********

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 
-DeepDiff 6.6.1 documentation!
+DeepDiff 6.7.0 documentation!
 =============================
 
 *******

--- a/docs/serialization.rst
+++ b/docs/serialization.rst
@@ -148,5 +148,22 @@ Example 2:
       {'action': 'iterable_item_added', 'path': [3], 'value': 'D'}]
 
 
+.. _delta_from_flat_dicts_label:
+
+Delta Load From Flat Dictionaries
+------------------------------------
+
+    >>> from deepdiff import DeepDiff, Delta
+    >>> t3 = ["A", "B"]
+    >>> t4 = ["A", "B", "C", "D"]
+    >>> diff = DeepDiff(t3, t4, verbose_level=2)
+    >>> delta = Delta(diff, verify_symmetry=True)
+    DeepDiff Deprecation: use bidirectional instead of verify_symmetry parameter.
+    >>> flat_dicts = delta.to_flat_dicts()
+    >>>
+    >>> delta2 = Delta(flat_dict_list=flat_dicts)
+    >>> t3 + delta == t4
+    True
+
 
 Back to :doc:`/index`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.6.1
+current_version = 6.7.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if sys.version_info.major == 2:  # pragma: no cover
 if os.environ.get('USER', '') == 'vagrant':
     del os.link
 
-version = '6.6.1'
+version = '6.7.0'
 
 
 def get_reqs(filename):

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -681,6 +681,13 @@ DELTA_CASES = {
         'to_delta_kwargs': {'directed': True},
         'expected_delta_dict': {'iterable_item_removed': {'root[4]': 4}}
     },
+    'delta_case20_quotes_in_path': {
+        't1': {"a']['b']['c": 1},
+        't2': {"a']['b']['c": 2},
+        'deepdiff_kwargs': {},
+        'to_delta_kwargs': {'directed': True},
+        'expected_delta_dict': {'values_changed': {'root["a\'][\'b\'][\'c"]': {'new_value': 2}}}
+    },
 }
 
 

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -297,6 +297,17 @@ class TestDeepDiffText:
         result = {}
         assert result == ddiff
 
+    def test_diff_quote_in_string(self):
+        t1 = {
+            "a']['b']['c": 1
+        }
+        t2 = {
+            "a']['b']['c": 2
+        }
+        diff = DeepDiff(t1, t2)
+        expected = {'values_changed': {'''root["a']['b']['c"]''': {'new_value': 2, 'old_value': 1}}}
+        assert expected == diff
+
     def test_bytes(self):
         t1 = {
             1: 1,

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -24,10 +24,20 @@ def test_path_to_elements(path, expected):
      5),
     ({1: [{'2': 'b'}, 3], 2: {4, 5}},
      "root[1][0]['2']",
-     'b'),
+     'b'
+     ),
     ({'test [a]': 'b'},
      "root['test [a]']",
-     'b'),
+     'b'
+     ),
+    ({"a']['b']['c": 1},
+     """root["a\\'][\\'b\\'][\\'c"]""",
+     1
+     ),
+    ({"a']['b']['c": 1},
+     """root["a']['b']['c"]""",
+     1
+     ),
 ])
 def test_get_item(obj, path, expected):
     result = extract(obj, path)

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,21 +1,26 @@
 import pytest
-from deepdiff.path import _path_to_elements, GET, GETATTR, extract, parse_path
+from deepdiff.path import _path_to_elements, GET, GETATTR, extract, parse_path, stringify_path, _add_to_elements
 
 
-@pytest.mark.parametrize('path, expected', [
-    ("root[4]['b'][3]", [(4, GET), ('b', GET), (3, GET)]),
-    ("root[4].b[3]", [(4, GET), ('b', GETATTR), (3, GET)]),
-    ("root[4].b['a3']", [(4, GET), ('b', GETATTR), ('a3', GET)]),
-    ("root[4.3].b['a3']", [(4.3, GET), ('b', GETATTR), ('a3', GET)]),
-    ("root.a.b", [('a', GETATTR), ('b', GETATTR)]),
-    ("root.hello", [('hello', GETATTR)]),
-    (r"root['a\rb']", [('a\rb', GET)]),
-    ("root", []),
-    (((4, GET), ('b', GET)), ((4, GET), ('b', GET))),
+@pytest.mark.parametrize('test_num, path, expected', [
+    (1, "root[4]['b'][3]", [(4, GET), ('b', GET), (3, GET)]),
+    (2, "root[4].b[3]", [(4, GET), ('b', GETATTR), (3, GET)]),
+    (3, "root[4].b['a3']", [(4, GET), ('b', GETATTR), ('a3', GET)]),
+    (4, "root[4.3].b['a3']", [(4.3, GET), ('b', GETATTR), ('a3', GET)]),
+    (5, "root.a.b", [('a', GETATTR), ('b', GETATTR)]),
+    (6, "root.hello", [('hello', GETATTR)]),
+    (7, "root['h']", [('h', GET)]),
+    (8, "root['a\rb']", [('a\rb', GET)]),
+    (9, "root['a\\rb']", [('a\\rb', GET)]),
+    (10, "root", []),
+    (11, ((4, GET), ('b', GET)), ((4, GET), ('b', GET))),
 ])
-def test_path_to_elements(path, expected):
+def test_path_to_elements(test_num, path, expected):
     result = _path_to_elements(path, root_element=None)
-    assert tuple(expected) == result
+    assert tuple(expected) == result, f"test_path_to_elements #{test_num} failed"
+    if isinstance(path, str):
+        path_again = stringify_path(path=result)
+        assert path == path_again, f"test_path_to_elements #{test_num} failed"
 
 
 @pytest.mark.parametrize('obj, path, expected', [
@@ -29,10 +34,6 @@ def test_path_to_elements(path, expected):
     ({'test [a]': 'b'},
      "root['test [a]']",
      'b'
-     ),
-    ({"a']['b']['c": 1},
-     """root["a\\'][\\'b\\'][\\'c"]""",
-     1
      ),
     ({"a']['b']['c": 1},
      """root["a']['b']['c"]""",
@@ -53,3 +54,23 @@ def test_parse_path():
     assert ['joe', 'age'] == result3
     result4 = parse_path("root['joe'].age", include_actions=True)
     assert [{'element': 'joe', 'action': 'GET'}, {'element': 'age', 'action': 'GETATTR'}] == result4
+
+
+@pytest.mark.parametrize('test_num, elem, inside, expected', [
+    (
+        1,
+        "'hello'",
+        None,
+        [('hello', GET)],
+    ),
+    (
+        2,
+        "'a\rb'",
+        None,
+        [('a\rb', GET)],
+    ),
+])
+def test__add_to_elements(test_num, elem, inside, expected):
+    elements = []
+    _add_to_elements(elements, elem, inside)
+    assert expected == elements

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -321,6 +321,8 @@ class TestDeepDiffPretty:
         (3, {'10': Decimal(2017)}, None),
         (4, Decimal(2017.1), None),
         (5, {1, 2, 10}, set),
+        (6, datetime.datetime(2023, 10, 11), datetime.datetime.fromisoformat),
+        (7, datetime.datetime.utcnow(), datetime.datetime.fromisoformat),
     ])
     def test_json_dumps_and_loads(self, test_num, value, func_to_convert_back):
         serialized = json_dumps(value)


### PR DESCRIPTION
- v6-7-0
    - Delta can be subtracted from other objects now.
    - verify_symmetry is deprecated. Use bidirectional instead.
    - always_include_values flag in Delta can be enabled to include values in the delta for every change.
    - Fix for Delta.__add__ breaks with esoteric dict keys.
    - You can load a delta from the list of flat dictionaries.
