### PR TITLE
python 3.12 CI/build workaround

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,15 +34,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
+    - name: Upgrade setuptools
+      if: matrix.python-version == 3.12
+      run: |
+        # workaround for 3.12, SEE: https://github.com/pypa/setuptools/issues/3661#issuecomment-1813845177
+        pip install --upgrade setuptools
     - name: Install dependencies py3.7
       if: matrix.python-version == 3.7
       run: pip install -r requirements-dev-3.7.txt
     - name: Install dependencies
       if: matrix.python-version != 3.7
-      run: |
-        # workaround for 3.12, SEE: https://github.com/pypa/setuptools/issues/3661#issuecomment-1813845177
-        pip install --upgrade setuptools
-        pip install -r requirements-dev.txt
+      run: pip install -r requirements-dev.txt
     - name: Install Numpy Dev
       if: ${{ matrix.numpy-version }}
       run: pip install -I --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple "numpy>=0.0.dev0" 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,7 +39,10 @@ jobs:
       run: pip install -r requirements-dev-3.7.txt
     - name: Install dependencies
       if: matrix.python-version != 3.7
-      run: pip install -r requirements-dev.txt
+      run: |
+        # workaround for 3.12, SEE: https://github.com/pypa/setuptools/issues/3661#issuecomment-1813845177
+        pip install --upgrade setuptools
+        pip install -r requirements-dev.txt
     - name: Install Numpy Dev
       if: ${{ matrix.numpy-version }}
       run: pip install -I --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple "numpy>=0.0.dev0" 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ bump2version==1.0.1
 jsonpickle==3.0.2
 coverage==6.5.0
 ipdb==0.13.13
-numpy==1.24.4
+numpy~=1.24.4
 pytest==7.4.2
 pytest-cov==4.1.0
 python-dotenv==0.21.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ bump2version==1.0.1
 jsonpickle==3.0.2
 coverage==6.5.0
 ipdb==0.13.13
-numpy~=1.24.4
+numpy>=1.24.4,<2.0.0
 pytest==7.4.2
 pytest-cov==4.1.0
 python-dotenv==0.21.0


### PR DESCRIPTION
Hi @seperman,

Thank you for creating this wonderful tool.  I came across trying to upgrade my project which uses deepdiff to python 3.12, and saw the error for python 3.12 on https://github.com/seperman/deepdiff/pull/449.

This PR attempts to fix the python 3.12 build.

Summary:
- conditionally upgrading setuptools for python 3.12 build before installing dependencies in requirements-dev.txt
- loosen version constraint of `numpy` in `requirements-dev.txt` to make the `pip install` step go through, as we are installing numpy 2.0.0-dev afterwards anyway

Thank you for your consideration, looking forward for version 6.7.2.  Feel free to let me know if there's anything you would like to change.

Best Regards,
Leo

References:
https://github.com/pypa/setuptools/issues/3661#issuecomment-1813845177