### PR TITLE
Delta constructor fix for flat_dict_list param (pull request back to dev branch)

### DIFF
--- a/deepdiff/delta.py
+++ b/deepdiff/delta.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 from functools import partial
 from collections.abc import Mapping
@@ -125,7 +126,8 @@ class Delta:
                 raise ValueError(BINIARY_MODE_NEEDED_MSG.format(e)) from None
             self.diff = _deserializer(content, safe_to_import=safe_to_import)
         elif flat_dict_list:
-            self.diff = self._from_flat_dicts(flat_dict_list)
+            # Use copy to preserve original value of flat_dict_list in calling module
+            self.diff = self._from_flat_dicts(copy.deepcopy(flat_dict_list))
         else:
             raise ValueError(DELTA_AT_LEAST_ONE_ARG_NEEDED)
 


### PR DESCRIPTION
Added fix and unit test for (bug) issue 457, [Issue 457](https://github.com/seperman/deepdiff/issues/457)

Scenario:
We found that when a flat_dict_list was provided as a constructor
parameter for instantiating a new delta, the provided flat_dict_list
is unexpectedly being mutated/changed, which can be troublesome for the
caller if they were expecting the flat_dict_list to be used BY COPY
rather than BY REFERENCE.

Intent:
Preserve the original value of the flat_dict_list variable within the
calling module/function after instantiating the new delta.