### PR TITLE
feature: optional pandas and polars support

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,3 +20,5 @@ tomli==2.0.1
 tomli-w==1.0.0
 pydantic==2.7.4
 pytest-benchmark==4.0.0
+pandas>=1.6
+polars=>0.19.11


### PR DESCRIPTION
Fixes #394.

I recently ran into an issue where my pipipegraph2 failed to to recalculate nodes downstream of a changed output because deepdiff assigned the same hash to different DataFrames.

Turns out, it was essentially only hashing the column names.

This PR fixes that for pandas, and while I had it open, for polars as well.

The code paths are optional on a successful pandas/polars import.

The added tests of course require pandas and polars. I tried for both with the older versions I listed in requirements-dev.txt and the current versions

I observe 3 failing & 3 error test cases here locally,
but they also failed before I touched the code, so I'll blame them on my local venv.


