### PR TITLE
Fix for iterable moved items what are found with iterable_compare_func

### DIFF
--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -862,30 +862,6 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
 
             else:  # check if item value has changed
 
-                # if (i != j):
-                #     # Item moved
-                #     change_level = level.branch_deeper(
-                #         x,
-                #         y,
-                #         child_relationship_class=child_relationship_class,
-                #         child_relationship_param=i,
-                #         child_relationship_param2=j
-                #     )
-                #     self._report_result('iterable_item_moved', change_level)
-
-                # item_id = id(x)
-                # if parents_ids and item_id in parents_ids:
-                #     continue
-                # parents_ids_added = add_to_frozen_set(parents_ids, item_id)
-
-                # # Go one level deeper
-                # next_level = level.branch_deeper(
-                #     x,
-                #     y,
-                #     child_relationship_class=child_relationship_class,
-                #     child_relationship_param=j)
-                # self._diff(next_level, parents_ids_added)
-
                 if (i != j and ((x == y) or self.iterable_compare_func)):
                     # Item moved
                     change_level = level.branch_deeper(
@@ -896,7 +872,6 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
                         child_relationship_param2=j
                     )
                     self._report_result('iterable_item_moved', change_level, local_tree=local_tree)
-                    continue
 
                 item_id = id(x)
                 if parents_ids and item_id in parents_ids:
@@ -904,12 +879,15 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
                 parents_ids_added = add_to_frozen_set(parents_ids, item_id)
 
                 # Go one level deeper
+                # Intentionally setting j as the first child relationship param in cases of a moved item.
+                # If the item was moved using an iterable_compare_func then we want to make sure that the index
+                # is relative to t2.
                 next_level = level.branch_deeper(
                     x,
                     y,
                     child_relationship_class=child_relationship_class,
-                    child_relationship_param=i,
-                    child_relationship_param2=j,
+                    child_relationship_param=j,
+                    child_relationship_param2=i
                 )
                 self._diff(next_level, parents_ids_added, local_tree=local_tree)
 

--- a/tests/fixtures/compare_func_result1.json
+++ b/tests/fixtures/compare_func_result1.json
@@ -1,40 +1,59 @@
 {
-    "dictionary_item_added": [
-        "root['Cars'][3]['dealers']"
-    ],
-    "dictionary_item_removed": [
-        "root['Cars'][3]['production']"
-    ],
-    "values_changed": {
-        "root['Cars'][3]['model']": {
-            "new_value": "Supra",
-            "old_value": "supra"
-        }
+  "dictionary_item_added": [
+    "root['Cars'][3]['dealers']"
+  ],
+  "dictionary_item_removed": [
+    "root['Cars'][3]['production']"
+  ],
+  "values_changed": {
+    "root['Cars'][2]['dealers'][0]['quantity']": {
+      "new_value": 50,
+      "old_value": 20
     },
-    "iterable_item_added": {
-        "root['Cars'][0]": {
-            "id": "7",
-            "make": "Toyota",
-            "model": "8Runner"
-        }
+    "root['Cars'][1]['model_numbers'][2]": {
+      "new_value": 3,
+      "old_value": 4
     },
-    "iterable_item_removed": {
-        "root['Cars'][1]": {
-            "id": "2",
-            "make": "Toyota",
-            "model": "Highlander",
-            "dealers": [
-                {
-                    "id": 123,
-                    "address": "123 Fake St",
-                    "quantity": 50
-                },
-                {
-                    "id": 125,
-                    "address": "125 Fake St",
-                    "quantity": 20
-                }
-            ]
-        }
+    "root['Cars'][3]['model']": {
+      "new_value": "Supra",
+      "old_value": "supra"
     }
+  },
+  "iterable_item_added": {
+    "root['Cars'][2]['dealers'][1]": {
+      "id": 200,
+      "address": "200 Fake St",
+      "quantity": 10
+    },
+    "root['Cars'][1]['model_numbers'][3]": 4,
+    "root['Cars'][0]": {
+      "id": "7",
+      "make": "Toyota",
+      "model": "8Runner"
+    }
+  },
+  "iterable_item_removed": {
+    "root['Cars'][2]['dealers'][0]": {
+      "id": 103,
+      "address": "103 Fake St",
+      "quantity": 50
+    },
+    "root['Cars'][1]": {
+      "id": "2",
+      "make": "Toyota",
+      "model": "Highlander",
+      "dealers": [
+        {
+          "id": 123,
+          "address": "123 Fake St",
+          "quantity": 50
+        },
+        {
+          "id": 125,
+          "address": "125 Fake St",
+          "quantity": 20
+        }
+      ]
+    }
+  }
 }

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -1879,7 +1879,14 @@ class TestDeltaCompareFunc:
                         "val": 3
                     }
                 }
-            }
+            },
+            'values_changed': {
+                "root[2]['val']": {
+                    'new_value': 3,
+                    'old_value': 1,
+                    'new_path': "root[0]['val']"
+                }
+            },
         }
         assert expected == ddiff
         delta = Delta(ddiff)
@@ -1888,6 +1895,7 @@ class TestDeltaCompareFunc:
 
         flat_result = delta.to_flat_rows()
         flat_expected = [
+            {'path': [2, 'val'], 'value': 3, 'action': 'values_changed', 'type': int, 'new_path': [0, 'val']},
             {'path': [2], 'value': {'id': 1, 'val': 3}, 'action': 'iterable_item_removed', 'type': dict},
             {'path': [0], 'value': {'id': 1, 'val': 3}, 'action': 'iterable_item_removed', 'type': dict},
             {'path': [3], 'value': {'id': 3, 'val': 3}, 'action': 'iterable_item_removed', 'type': dict},
@@ -1930,6 +1938,12 @@ class TestDeltaCompareFunc:
                         'val': 3
                     }
                 }
+            },
+            'values_changed': {
+                "root[2]['val']": {
+                    'new_value': 3,
+                    'new_path': "root[0]['val']"
+                }
             }
         }
         assert expected_delta_dict == delta_again.diff
@@ -1961,7 +1975,14 @@ class TestDeltaCompareFunc:
                         'val': 1
                     }
                 }
-            }
+            },
+            'values_changed': {
+                "root[0]['val']": {
+                    'new_value': 1,
+                    'old_value': 3,
+                    'new_path': "root[2]['val']"
+                }
+            },
         }
         assert expected == ddiff
         delta = Delta(ddiff)


### PR DESCRIPTION
Our usage of deepdiff heavily involves iterable_compare_func and we have been unable to upgrade past 6.1.0 because of an issue that was introduced in [this changeset](https://github.com/seperman/deepdiff/commit/b0a70d3ae5e279855f1ce2d7d2817a0b5f1a028c).

There are two key changes:

1. When an item is moved, rather than stopping the current iteration, continue to go one level deeper the way item added and removed do.
2. Purposely make moved items relative to t2 rather than t1. This keeps it consistent with other change types. This was originally introduced with [this changeset](https://github.com/seperman/deepdiff/commit/a3c06844) but later got changed around.

This PR should fix this issue:

https://github.com/seperman/deepdiff/issues/414