### PR TITLE
Fix _dict_from_slots, solves Path comparison

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -63,3 +63,4 @@ Authors in order of the timeline of their contributions:
 - [sf-tcalhoun](https://github.com/sf-tcalhoun) for fixing "Instantiating a Delta with a flat_dict_list unexpectedly mutates the flat_dict_list"
 - [dtorres-sf](https://github.com/dtorres-sf) for fixing iterable moved items when iterable_compare_func is used.
 - [Florian Finkernagel](https://github.com/TyberiusPrime) for pandas and polars support.
+- Mathis Chenuet [artemisart](https://github.com/artemisart) for fixing slots classes comparison.

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -421,7 +421,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
                 else:
                     all_slots.extend(slots)
 
-        return {i: getattr(object, unmangle(i), None) for i in all_slots}
+        return {i: getattr(object, key) for i in all_slots if hasattr(object, key := unmangle(i))}
 
     def _diff_enum(self, level, parents_ids=frozenset(), local_tree=None):
         t1 = detailed__dict__(level.t1, include_keys=ENUM_INCLUDE_KEYS)

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -421,7 +421,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
                 else:
                     all_slots.extend(slots)
 
-        return {i: getattr(object, unmangle(i)) for i in all_slots}
+        return {i: getattr(object, unmangle(i), None) for i in all_slots}
 
     def _diff_enum(self, level, parents_ids=frozenset(), local_tree=None):
         t1 = detailed__dict__(level.t1, include_keys=ENUM_INCLUDE_KEYS)

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -1713,7 +1713,7 @@ class TestDeepDiffText:
         t2 = Bad()
 
         ddiff = DeepDiff(t1, t2)
-        result = {'unprocessed': ['root: Bad Object and Bad Object']}
+        result = {}
         assert result == ddiff
 
     def test_dict_none_item_removed(self):


### PR DESCRIPTION
Hello, I figured out some `__slots__` could be not set which makes getattr fails and so `DeepDiff._dict_from_slots` fails, which is what makes Path comparison impossible currently:
```py
from pathlib import Path

obj = Path('/test/yo')
keys = [key for cls in obj.__class__.__mro__ for key in getattr(cls, '__slots__', ())]
print(keys)
{k: getattr(obj, k, 'not present') for k in keys}
# gives:
['_drv', '_root', '_parts', '_str', '_hash', '_pparts', '_cached_cparts']
{'_drv': '',
 '_root': '/',
 '_parts': ['/', 'test', 'yo'],
 '_str': 'not present',
 '_hash': 'not present',
 '_pparts': 'not present',
 '_cached_cparts': 'not present'}
```

I fixed this with a hasattr in `_dict_from_slots`.

Impact:
```py
from deepdiff import DeepDiff
from pathlib import Path

DeepDiff(Path('a'), Path('b/b'))
# Before this change
# {'unprocessed': ['root: a and b/b']}
# After this change
# {'values_changed': {'root._parts[0]': {'new_value': 'b', 'old_value': 'a'}}, 'iterable_item_added': {'root._parts[1]': 'b'}}
```

Solves #231