### PR TITLE
Add print() option

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -64,3 +64,4 @@ Authors in order of the timeline of their contributions:
 - [dtorres-sf](https://github.com/dtorres-sf) for fixing iterable moved items when iterable_compare_func is used.
 - [Florian Finkernagel](https://github.com/TyberiusPrime) for pandas and polars support.
 - Mathis Chenuet [artemisart](https://github.com/artemisart) for fixing slots classes comparison.
+- [Aaron D. Marasco](https://github.com/AaronDMarasco) added `prefix` option to `pretty()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 - v8-0-1
     - Bugfix. Numpy should be optional.
+    - Added `prefix` option to `pretty()`
 
 - v8-0-0
 

--- a/deepdiff/serialization.py
+++ b/deepdiff/serialization.py
@@ -296,7 +296,7 @@ class SerializationMixin:
 
         return deepcopy(dict(result))
 
-    def pretty(self):
+    def pretty(self, prefix=None):
         """
         The pretty human readable string output for the diff object
         regardless of what view was used to generate the diff.
@@ -310,12 +310,16 @@ class SerializationMixin:
             Item root[1] removed from set.
         """
         result = []
+        if prefix is None:
+            prefix = ''
         keys = sorted(self.tree.keys())  # sorting keys to guarantee constant order across python versions.
         for key in keys:
             for item_key in self.tree[key]:
                 result += [pretty_print_diff(item_key)]
 
-        return '\n'.join(result)
+        if callable(prefix):
+            return "\n".join(f"{prefix(diff=self)}{r}" for r in result)
+        return "\n".join(f"{prefix}{r}" for r in result)
 
 
 class _RestrictedUnpickler(pickle.Unpickler):

--- a/docs/view.rst
+++ b/docs/view.rst
@@ -299,6 +299,29 @@ Use the pretty method for human readable output. This is regardless of what view
     Item root[4] removed from set.
     Item root[1] removed from set.
 
+The pretty method has an optional parameter ``prefix`` that allows a prefix string before every output line (*e.g.* for logging):
+    >>> from deepdiff import DeepDiff
+    >>> t1={1,2,4}
+    >>> t2={2,3}
+    >>> print(DeepDiff(t1, t2).pretty(prefix='Diff: '))
+    Diff: Item root[3] added to set.
+    Diff: Item root[4] removed from set.
+    Diff: Item root[1] removed from set.
+
+The ``prefix`` may also be a callable function. This function must accept ``**kwargs``; as of this version, the only parameter is ``diff`` but the signature allows for future expansion.
+The ``diff`` given will be the ``DeepDiff`` that ``pretty`` was called on; this allows interesting capabilities such as:
+    >>> from deepdiff import DeepDiff
+    >>> t1={1,2,4}
+    >>> t2={2,3}
+    >>> def callback(**kwargs):
+    ...     """Helper function using a hidden variable on the diff that tracks which count prints next"""
+    ...     kwargs['diff']._diff_count = 1 + getattr(kwargs['diff'], '_diff_count', 0)
+    ...     return f"Diff #{kwargs['diff']._diff_count}: "
+    ...
+    >>> print(DeepDiff(t1, t2).pretty(prefix=callback))
+    Diff #1: Item root[3] added to set.
+    Diff #2: Item root[4] removed from set.
+    Diff #3: Item root[1] removed from set.
 
 
 Text view vs. Tree view vs. vs. pretty() method


### PR DESCRIPTION
Allows a user-defined string (or callback function) to prefix every output when using the `pretty()` call.