### PR TITLE
Only lower if clean_key is instance of str

### DIFF
--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -530,7 +530,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, Base):
                 clean_key = KEY_TO_VAL_STR.format(type_, clean_key)
             else:
                 clean_key = key
-            if self.ignore_string_case:
+            if self.ignore_string_case and isinstance(clean_key, str):
                 clean_key = clean_key.lower()
             if clean_key in result:
                 logger.warning(('{} and {} in {} become the same key when ignore_numeric_type_changes'

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -2147,3 +2147,25 @@ class TestDeepDiffText:
 
         diff = DeepDiff(t1, t2, exclude_regex_paths=["any"])
         assert {'values_changed': {'root[MyDataClass(val=2,val2=4)]': {'new_value': 10, 'old_value': 20}}} == diff
+
+
+    def test_group_by_with_none_key_and_ignore_case(self):
+        """Test that group_by works with None keys when ignore_string_case is True"""
+        dict1 = [{'txt_field': 'FULL_NONE', 'group_id': None}, {'txt_field': 'FULL', 'group_id': 'a'}]
+        dict2 = [{'txt_field': 'PARTIAL_NONE', 'group_id': None}, {'txt_field': 'PARTIAL', 'group_id': 'a'}]
+
+        diff = DeepDiff(
+            dict1,
+            dict2,
+            ignore_order=True,
+            group_by='group_id',
+            ignore_string_case=True
+        )
+
+        expected = {'values_changed': {"root[None]['txt_field']":
+                                           {'new_value': 'partial_none', 'old_value': 'full_none'},
+                                       "root['a']['txt_field']":
+                                           {'new_value': 'partial', 'old_value': 'full'}
+                                        }
+                    }
+        assert expected == diff


### PR DESCRIPTION
Fix AttributeError when group_by key is None with ignore_string_case
## Related Issue
Fixes #503 

## Description
This PR fixes a bug where using `group_by` with a nullable key raises an AttributeError when `ignore_string_case=True`. The error occurs because the code attempts to call `.lower()` on None values.

## Changes
- Modified the string case conversion logic in `diff.py` to check if the key is a string before applying `.lower()`
- Added type checking using `isinstance(clean_key, str)` to safely handle None values
- +1: Black formatting was automatically for `tests/test_diff_text.py`, @seperman let me know if it's an issue and I should revert.
## Before
```python
if self.ignore_string_case:
    clean_key = clean_key.lower()
```

## After
```python
if self.ignore_string_case and isinstance(clean_key, str):
    clean_key = clean_key.lower()
```

## Testing
Added test case:
```python
dict1 = [{'txt_field': 'FULL', 'group_id': None}]
dict2 = [{'txt_field': 'FULL', 'group_id': 'a'}]
diff = DeepDiff(
    dict1,
    dict2,
    ignore_order=True,
    group_by='group_id',
    ignore_string_case=True
)
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes