### PR TITLE
Fix broken tests

### DIFF
--- a/deepdiff/delta.py
+++ b/deepdiff/delta.py
@@ -98,11 +98,24 @@ class Delta:
                     for path, op_codes in result['_iterable_opcodes'].items():
                         _iterable_opcodes[path] = []
                         for op_code in op_codes:
-                            _iterable_opcodes[path].append(
-                                Opcode(
-                                    **op_code
+                            if isinstance(op_code, list):
+                                # Handle list format: [tag, t1_from, t1_to, t2_from, t2_to, old_values, new_values]
+                                _iterable_opcodes[path].append(
+                                    Opcode(
+                                        tag=op_code[0],
+                                        t1_from_index=op_code[1],
+                                        t1_to_index=op_code[2], 
+                                        t2_from_index=op_code[3],
+                                        t2_to_index=op_code[4],
+                                        old_values=op_code[5],
+                                        new_values=op_code[6]
+                                    )
                                 )
-                            )
+                            else:
+                                # Handle dict format
+                                _iterable_opcodes[path].append(
+                                    Opcode(**op_code)
+                                )
                     result['_iterable_opcodes'] = _iterable_opcodes
                 return result
 

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -2436,9 +2436,9 @@ class TestDeltaCompareFunc:
         flat_rows = delta2.to_flat_rows()
 
         expected_flat_rows = [
-            FlatDeltaRow(path=[3], action='values_changed', value='X', old_value='D', type=str, old_type=str, new_path=[2]),
-            FlatDeltaRow(path=[6], action='values_changed', value='Z', old_value='G', type=str, old_type=str),
-            FlatDeltaRow(path=[5], action='values_changed', value='Y', old_value='F', type=str, old_type=str),
+            FlatDeltaRow(path=[3], action=FlatDataAction.values_changed, value='X', old_value='D', type=str, old_type=str, new_path=[2]),
+            FlatDeltaRow(path=[6], action=FlatDataAction.values_changed, value='Z', old_value='G', type=str, old_type=str),
+            FlatDeltaRow(path=[5], action=FlatDataAction.values_changed, value='Y', old_value='F', type=str, old_type=str),
             FlatDeltaRow(path=[], action=FlatDataAction.iterable_items_deleted, value=[], old_value=['A'], type=list, old_type=list, t1_from_index=0, t1_to_index=1, t2_from_index=0, t2_to_index=0),
             FlatDeltaRow(path=[], action=FlatDataAction.iterable_items_equal, value=None, old_value=None, type=type(None), old_type=type(None), t1_from_index=1, t1_to_index=3, t2_from_index=0, t2_to_index=2),
             FlatDeltaRow(path=[], action=FlatDataAction.iterable_items_replaced, value=['X'], old_value=['D', 'E', 'F', 'G'], type=list, old_type=list, t1_from_index=3, t1_to_index=7, t2_from_index=2, t2_to_index=3),


### PR DESCRIPTION
A few tests failed when I tried to run my changes for #504 
```
FAILED tests/test_delta.py::TestDeltaCompareFunc::test_list_of_alphabet_and_its_delta - TypeError: deepdiff.helper.Opcode() argument after ** must be a mapping, not list
FAILED tests/test_serialization.py::TestSerialization::test_serialization_text - TypeError: argument of type 'NoneType' is not iterable
FAILED tests/test_serialization.py::TestSerialization::test_deserialization - assert {'type_changes': {"root[4]['b']": {'old_type': <class 'list'>, 'new_type': <class 'str'>, 'old_value': [1, 2, 3], 'new_value': 'world\n\n\nEnd'}}} == None
FAILED tests/test_serialization.py::TestSerialization::test_serialization_tree - TypeError: argument of type 'NoneType' is not iterable
FAILED tests/test_serialization.py::TestSerialization::test_deserialization_tree - TypeError: argument of type 'NoneType' is not iterable
FAILED tests/test_serialization.py::TestDeepDiffPretty::test_namedtuple_seriazliation - assert '["replace", ..., null, null]' == '{"tag":"repl...values":null}'
FAILED tests/test_serialization.py::TestDeepDiffPretty::test_reversed_list - AssertionError: assert '[3,2,1]' == '[3, 2, 1]'
ERROR tests/test_lfucache.py::TestLFUcache::test_lfu[items0-3-expected_results0-1.333]
ERROR tests/test_lfucache.py::TestLFUcache::test_lfu[items1-3-expected_results1-1.666]
ERROR tests/test_lfucache.py::TestLFUcache::test_lfu[items2-3-expected_results2-3.333]
```

### TestDeltaCompareFunc::test_list_of_alphabet_and_its_delta
delta.py test was failing to properly deserialize opcodes when they were in list format from JSON.

 Added handling for both dictionary and list format opcodes during deserialization.
 List format opcodes contain [tag, t1_from, t1_to, t2_from, t2_to, old_values, new_values].

 This fixes test failures in test_list_of_alphabet_and_its_delta when using JSON serialization.