### PR TITLE
Fixes issue where the key deep_distance is not returned when both compared items are equal

### DIFF
--- a/deepdiff/model.py
+++ b/deepdiff/model.py
@@ -41,7 +41,7 @@ class ResultDict(RemapDict):
         Remove empty keys from this object. Should always be called after the result is final.
         :return:
         """
-        empty_keys = [k for k, v in self.items() if not v]
+        empty_keys = [k for k, v in self.items() if not isinstance(v, (int)) and not v]
 
         for k in empty_keys:
             del self[k]
@@ -88,7 +88,7 @@ class TreeResult(ResultDict):
         return self.get(item)
 
     def __len__(self):
-        return sum([len(i) for i in self.values() if isinstance(i, SetOrdered)])
+        return sum([len(i) for i in self.values() if isinstance(i, SetOrdered)]) + len([i for i in self.values() if isinstance(i, int)])
 
 
 class TextResult(ResultDict):


### PR DESCRIPTION
Hi, Sep. I use your library for some evals code and I realized DeepDiff doesn't send back the key "deep_distance" when comparing exact matches. I read the docs and there is no explicit mention that it shouldn't. I expect a deep_distance=0 returned at least when I ask for it using get_deep_distance=True.

I had some checks in my code on top of this. But then I wanted to make sure and when down debugging your code. 

I found two issues.

One is if deep_distance is 0, [remove_empty_keys](https://github.com/seperman/deepdiff/blob/6d8a4c7c32d5ac57919955954790be994d01fe57/deepdiff/model.py#L44) treats it as empty. I added a very simple check. If the item is an instance of int, then it should have some value. Thus it's not empty.

Second, the [`__len__`](https://github.com/seperman/deepdiff/blob/6d8a4c7c32d5ac57919955954790be994d01fe57/deepdiff/model.py#L91) function only expects to deal with SetOrdered instances so I just added an int there. 

I hope this fits with your design goals. Let me know if I misunderstood the docs. Otherwise, feel free to make edits as you please before merging. 