### PR TITLE
DeepDiff Fails to Detect Timezone Changes in Arrays with ignore_order=True

### DIFF
--- a/deepdiff/helper.py
+++ b/deepdiff/helper.py
@@ -623,10 +623,10 @@ def datetime_normalize(truncate_datetime, obj):
             obj = obj.replace(minute=0, second=0, microsecond=0)
         elif truncate_datetime == 'day':
             obj = obj.replace(hour=0, minute=0, second=0, microsecond=0)
-    if isinstance(obj, datetime.datetime):
-        obj = obj.replace(tzinfo=datetime.timezone.utc)
-    elif isinstance(obj, datetime.time):
-        obj = time_to_seconds(obj)
+        if isinstance(obj, datetime.datetime):
+            obj = obj.replace(tzinfo=datetime.timezone.utc)
+        elif isinstance(obj, datetime.time):
+            obj = time_to_seconds(obj)
     return obj
 
 

--- a/tests/test_diff_datetime.py
+++ b/tests/test_diff_datetime.py
@@ -22,6 +22,9 @@ class TestDiffDatetime:
         res_ignore = DeepDiff(d1, d2, ignore_order=True)
         assert res_ignore == expected
 
+        res_truncate = DeepDiff(d1, d2, truncate_datetime='second')
+        assert res_truncate == {}
+
 
     def test_datetime_diff(self):
         """Testing for the correct setting and usage of epsilon."""

--- a/tests/test_diff_datetime.py
+++ b/tests/test_diff_datetime.py
@@ -1,8 +1,28 @@
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timezone
 from deepdiff import DeepDiff
 
 
 class TestDiffDatetime:
+    def test_datetime_within_array_with_timezone_diff(self):
+        """Testing for the correct setting and usage of epsilon."""
+        d1 = [datetime(2020, 8, 31, 13, 14, 1)]
+        d2 = [datetime(2020, 8, 31, 13, 14, 1, tzinfo=timezone.utc)]
+
+        res = DeepDiff(d1, d2)
+        expected = {
+            "values_changed": {
+                "root[0]": {
+                    "new_value": datetime(2020, 8, 31, 13, 14, 1, tzinfo=timezone.utc),
+                    "old_value": datetime(2020, 8, 31, 13, 14, 1),
+                }
+            }
+        }
+        assert res == expected
+
+        res_ignore = DeepDiff(d1, d2, ignore_order=True)
+        assert res_ignore == expected
+
+
     def test_datetime_diff(self):
         """Testing for the correct setting and usage of epsilon."""
         d1 = {"a": datetime(2023, 7, 5, 10, 11, 12)}


### PR DESCRIPTION
Solution proposal for issue https://github.com/seperman/deepdiff/issues/516

**Description**

The `deepdiff` library is unable to detect timezone changes in datetimes within arrays.

When `ignore_order=True` and a datetime is present within an array, `deepdiff` uses an execution path that makes a `DeepHash`. Due to the implementation of `datetime_normalize`, all datetimes have their timezone set to UTC:

https://github.com/seperman/deepdiff/blob/c7183695a8b2049e53cfabc48c7b5adb28e45185/deepdiff/helper.py#L627

This behavior causes issues in our use case, as we rely on deepdiff to detect changes in datetime objects, including changes to their timezones.

**Changes**

Indent logic which replaces timezone to only affect those which has set `truncate_datetime`.

**Notes**

Existing logic was added in commits
* https://github.com/seperman/deepdiff/commit/99050166aad57d1db08461f5c878ee7042db62f4
* https://github.com/seperman/deepdiff/commit/7d399229e96b6c316a4a8234d63ea5a326abe65e