### PR TITLE
Add missing pytz requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 orderly-set>=5.3.0,<6
+pytz


### PR DESCRIPTION
The latest release looks like it started using `pytz`:
https://github.com/seperman/deepdiff/blob/master/deepdiff/diff.py#L8

Trying to build from source on conda-forge resulted in an import error, so this adds `pytz` as an explicit requirement.