### PR TITLE
Fix for moving nested tables when using iterable_compare_func.

### DIFF
--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -952,11 +952,10 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, DeepDiffProtocol, 
                     self._report_result('iterable_item_moved', change_level, local_tree=local_tree)
 
                     if self.iterable_compare_func:
-                        # Intentionally setting j as the first child relationship param in cases of a moved item.
-                        # If the item was moved using an iterable_compare_func then we want to make sure that the index
-                        # is relative to t2.
-                        reference_param1 = j
-                        reference_param2 = i
+                        # Mark additional context denoting that we have moved an item.
+                        # This will allow for correctly setting paths relative to t2 when using an iterable_compare_func
+                        level.additional["moved"] = True
+
                     else:
                         continue
 


### PR DESCRIPTION
This fixes issue #540 . Before this change the reference params were being swapped right after there was a move. This is because the move needed to have the original paths, but child changes needed the new paths. The problem was that nested moves swapped the reference parameters again after the move was recorded. This made the paths inaccurate since the parent did not have the params swapped but the child did.

Instead, we are no longer swapping when building the tree, but rather when we request the paths. The paths will not be swapped for the iterable_item_moved but it will be swapped for all other changes if there was a parent with an iterable_item_moved.