### PR TITLE
Fix test_delta.py with Python 3.14.

### DIFF
--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -195,7 +195,8 @@ class TestBasicsOfDelta:
             delta._simple_set_elem_value(
                 obj={}, elem={1}, value=None, action=GET, path_for_err_reporting='mypath')
         assert str(excinfo.value) in {"Failed to set mypath due to unhashable type: 'set'",
-                                      "Failed to set mypath due to 'set' objects are unhashable"}
+                                      "Failed to set mypath due to 'set' objects are unhashable",
+                                      "Failed to set mypath due to cannot use 'set' as a dict key (unhashable type: 'set')"}
 
     def test_simple_delete_elem(self):
         delta = Delta({}, raise_errors=True)


### PR DESCRIPTION
It seems python 3.14 changes the error description of that test a bit. This was reported on Fedora side via https://bugzilla.redhat.com/show_bug.cgi?id=2374300

This was done similarly to a similar change in https://github.com/seperman/deepdiff/commit/dc85851a5c58f0e9c29c0a2db34ec80fd2a0a6c0 for Python 3.5