### PR TITLE
Fix: Colored view displays empty list [] when all items are removed

### DIFF
--- a/deepdiff/colored_view.py
+++ b/deepdiff/colored_view.py
@@ -109,9 +109,10 @@ class ColoredView:
             return '{\n' + ',\n'.join(items) + f'\n{current_indent}' + '}'
 
         elif isinstance(obj, (list, tuple)):
-            if not obj:
-                return '[]'
             removed_map = self._get_path_removed(path)
+            if not obj and not removed_map:
+                return '[]'
+
             for index in removed_map:
                 self._colorize_skip_paths.add(f"{path}[{index}]")
 

--- a/tests/test_colored_view.py
+++ b/tests/test_colored_view.py
@@ -134,6 +134,36 @@ def test_colored_view_list_additions():
     assert result == expected
 
 
+def test_colored_view_list_all_items_removed():
+    """Test that all removed items are displayed when list becomes empty."""
+    t1 = [2, 4]
+    t2 = []
+
+    diff = DeepDiff(t1, t2, view=COLORED_VIEW)
+    result = str(diff)
+
+    expected = f'''[
+  {RED}2{RESET},
+  {RED}4{RESET}
+]'''
+    assert result == expected
+
+
+def test_colored_compact_view_list_all_items_removed():
+    """Test that all removed items are displayed when list becomes empty with compact view."""
+    t1 = [2, 4]
+    t2 = []
+
+    diff = DeepDiff(t1, t2, view=COLORED_COMPACT_VIEW)
+    result = str(diff)
+
+    expected = f'''[
+  {RED}2{RESET},
+  {RED}4{RESET}
+]'''
+    assert result == expected
+
+
 def test_colored_view_list_changes_deletions():
     t1 = [1, 5, 7, 3, 6]
     t2 = [1, 2, 3, 4]


### PR DESCRIPTION
## Summary

Fixes a bug where COLORED_VIEW and COLORED_COMPACT_VIEW would display an empty list [] instead of showing removed items in red when all list items are removed.

## Problem
When all items are removed from a list (t2 becomes empty), the colored view displays [] instead of the removed items in red.

## Root Cause
In colored_view.py, _colorize_json() returned '[]' immediately when the list was empty, without checking for removed items.

## Solution
Check for removed items before returning empty list representation.

## Changes
- deepdiff/colored_view.py: Fixed early return logic
- tests/test_colored_view.py: Added 2 test cases

## Testing
All 18 tests pass including 2 new tests for this bug.