### PR TITLE
Fix bug in DeepHash for classes with uninitialised slots

### DIFF
--- a/deepdiff/deephash.py
+++ b/deepdiff/deephash.py
@@ -400,7 +400,7 @@ class DeepHash(Base):
             obj_to_dict_strategies.append(lambda o: o.__dict__)
 
         if hasattr(obj, "__slots__"):
-            obj_to_dict_strategies.append(lambda o: {i: getattr(o, i) for i in o.__slots__})
+            obj_to_dict_strategies.append(lambda o: {i: getattr(o, i) for i in o.__slots__ if hasattr(o, i)})
         else:
             import inspect
             obj_to_dict_strategies.append(lambda o: dict(inspect.getmembers(o, lambda m: not inspect.isroutine(m))))


### PR DESCRIPTION
hey @seperman 👋 

Minimal example that breaks the current implementation:

```python
class Foo:
    __slots__ = ("a", "b")

    def __init__(self, a):
        self.a = a

foo = Foo(1)
DeepHash(foo)
# Can not hash the following items: [<__main__.Foo object at 0x000>].
# {<object object at 0x000>: [<__main__.Foo object at 0x000>], <__main__.Foo object at 0x000>: Error: Unprocessed}
```

Took the liberty of implementing some more comprehensive tests for classes with slots to capture inheritance shenanigans 
