### PR TITLE
Ensure that delta replays apply changes to correct t1/t2 based on usage of iterable_compare_func

### DIFF
--- a/deepdiff/delta.py
+++ b/deepdiff/delta.py
@@ -551,8 +551,13 @@ class Delta:
             return elements, parent, parent_to_obj_elem, parent_to_obj_action, obj, elem, action
 
     def _do_values_or_type_changed(self, changes, is_type_change=False, verify_changes=True):
+        compare_func_was_used = self.diff.get('_iterable_compare_func_was_used', False)
         for path, value in changes.items():
-            elem_and_details = self._get_elements_and_details(path)
+            # When iterable_compare_func is used, keys in values_changed/type_changes are
+            # t2 paths and new_path holds the original t1 path. Always apply at t1 so we
+            # don't access indices that don't exist yet or modify the wrong item.
+            apply_path = value['new_path'] if (compare_func_was_used and value.get('new_path')) else path
+            elem_and_details = self._get_elements_and_details(apply_path)
             if elem_and_details:
                 elements, parent, parent_to_obj_elem, parent_to_obj_action, obj, elem, action = elem_and_details
             else:

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -2932,3 +2932,65 @@ class TestDeltaCompareFunc:
         beforeImageAgain2 = allAfterImage - delta2
         diff4 = DeepDiff(beforeImage, beforeImageAgain2, ignore_order=True)
         assert not diff4
+
+    def test_moved_and_changed_flat(self):
+        """Items that both move (due to prepended inserts) and change values
+        should produce t2 with no phantom entries after delta replay."""
+        t1 = [{"id": "a", "val": 1}, {"id": "b", "val": 2},
+            {"id": "c", "val": 3}]
+        t2 = [
+            {"id": "new1", "val": 10},  # inserted at [0]
+            {"id": "new2", "val": 20},  # inserted at [1]
+            {"id": "a", "val": 0.5},    # moved [0]→[2], val changed
+            {"id": "b", "val": 1.0},    # moved [1]→[3], val changed
+            {"id": "c", "val": 1.5},    # moved [2]→[4], val changed
+        ]
+        ddiff = DeepDiff(t1, t2, iterable_compare_func=self.compare_func,
+                        threshold_to_diff_deeper=0)
+        result = t1 + Delta(ddiff, force=True, raise_errors=True,
+                            log_errors=False)
+        assert [item for item in result if "id" not in item] == [], \
+            "Phantom entries (dicts missing 'id') found in result"
+        assert result == t2
+
+    def test_moved_and_changed_nested(self):
+        """Same bug in a nested structure: inner list items that both move and
+        change values should produce no phantom entries after delta replay."""
+        t1 = {"rows": [
+            {"id": "r1", "items": [{"id": "a", "val": 1},
+                                {"id": "b", "val": 2}]},
+            ]}
+        t2 = {"rows": [
+            {"id": "r1", "items": [
+                {"id": "new1", "val": 99},  # inserted at [0]
+                {"id": "a", "val": 0.5},    # moved [0]→[1], val changed
+                {"id": "b", "val": 1.0},    # moved [1]→[2], val changed
+            ]},
+        ]}
+        ddiff = DeepDiff(t1, t2, iterable_compare_func=self.compare_func,
+                        threshold_to_diff_deeper=0)
+        result = t1 + Delta(ddiff, force=True, raise_errors=True,
+                            log_errors=False)
+        assert [item for item in result["rows"][0][
+            "items"] if "id" not in item] == [], \
+            "Phantom entries (dicts missing 'id') found in nested result"
+        assert result == t2
+
+    def test_appended_only_no_movement_sanity_check(self):
+        """
+        When new items are only appended (existing items keep their positions),
+        stock Delta produces the correct result with no phantom entries.
+        """
+        t1 = [{"id": "a", "val": 1}, {"id": "b", "val": 2}]
+        t2 = [
+            {"id": "a", "val": 0.5},    # stays at [0], val changed
+            {"id": "b", "val": 1.0},    # stays at [1], val changed
+            {"id": "new1", "val": 10},  # appended
+            {"id": "new2", "val": 20},  # appended
+        ]
+        ddiff = DeepDiff(t1, t2, iterable_compare_func=self.compare_func,
+                        threshold_to_diff_deeper=0)
+        result = t1 + Delta(ddiff, force=True, raise_errors=True,
+                            log_errors=False)
+        assert [item for item in result if "id" not in item] == []
+        assert result == t2


### PR DESCRIPTION
Right now when an iterable_compare_func is used, there is a bug that occurs when items both move and change values. What happens is t2 ends up with phantom entries that shouldn't exist in the resulting replay. 

The tests below reproduce this at both a surface level and a nested structure.

Part of this issue is the order in which the we apply changes and movements. Currently, to mirror operations in DeepDiff, we apply removals/additions AFTER we apply changes. If we were to flip this (do movement first, then changes), it would actually solve this problem - but this has other implications.

The proposed solutions takes into account that when we go to apply changes, if an iterable_compare_func was used then the original t1 path is actually what we refer to as "new_path" at this point. When iterable_compare_func is not used, then the default path points to the original t1 path. If we always apply changes to the original t1 path, then we don't end up building these phantom entries in t2.

An alternative approach I have explored/tested includes filtering whether or not to apply changes based on if we expect those changes to be overridden by pending movements anyways. This effectively will skip operations that by default are "pointless" (bound to be overridden anyways), and as a side effect it will prevent this bug. Here is some sample code for that (also inside of `deepdiff/delta.py`):

```
def _filter_changes_covered_by_opcodes_or_moved(self, changes):
        """Return a filtered copy of *changes*, dropping entries that are
        already fully handled by either ``_iterable_opcodes`` or
        ``iterable_item_moved``.
        * ``_iterable_opcodes``: the replace opcode already encodes the correct
          new value; applying the change again would operate on stale t1 indices.
        * ``iterable_item_moved``: the moved entry already carries the complete
          new value; the sub-field change path uses a t2 index that does not
          exist yet when the change is applied (before items are inserted).
        """
        _iterable_opcodes = self.diff.get('_iterable_opcodes', {})
        iterable_item_moved = self.diff.get('iterable_item_moved', {})
        if not _iterable_opcodes and not iterable_item_moved:
            return changes
        filtered = {}
        for path, value in changes.items():
            # Check _iterable_opcodes: skip if direct parent list is handled.
            if _iterable_opcodes:
                parent_path = re.sub(r'\[\d+\]$', '', path)
                if parent_path in _iterable_opcodes:
                    continue
            # Check iterable_item_moved: skip if the sub-field belongs to a
            # moved item (new_path gives the t1 path; its parent is the item).
            if iterable_item_moved:
                new_path = value.get('new_path', '')
                if new_path:
                    item_path = re.sub(r'(\[[^\]]*\]|\.\w+)$', '', new_path)
                    if item_path in iterable_item_moved:
                        continue
            filtered[path] = value
        return filtered

    def _do_values_changed(self):
        values_changed = self.diff.get('values_changed')
        if values_changed:
            values_changed = self._filter_changes_covered_by_opcodes_or_moved(values_changed)
            self._do_values_or_type_changed(values_changed)

    def _do_type_changes(self):
        type_changes = self.diff.get('type_changes')
        if type_changes:
            type_changes = self._filter_changes_covered_by_opcodes_or_moved(type_changes)
            self._do_values_or_type_changed(type_changes, is_type_change=True)
```

I wanted to go ahead and propose these two potential fixes, but I am definitely open to alternative approaches if anything else comes to mind, or if these changes have associated risk that I am missing.

Thanks!