### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you want to improve the performance of DeepDiff with certain functionalities 
 Install optional packages:
 - [yaml](https://pypi.org/project/PyYAML/)
 - [tomli](https://pypi.org/project/tomli/) (python 3.10 and older) and [tomli-w](https://pypi.org/project/tomli-w/) for writing
-- [clevercsv](https://pypi.org/project/clevercsv/) for more rubust CSV parsing
+- [clevercsv](https://pypi.org/project/clevercsv/) for more robust CSV parsing
 - [orjson](https://pypi.org/project/orjson/) for speed and memory optimized parsing
 - [pydantic](https://pypi.org/project/pydantic/)
 


### PR DESCRIPTION
Convert from `rubust` to `robust`