### PR TITLE
fix: colored view not showing removed items when list is emptied (#575)

### DIFF
--- a/deepdiff/colored_view.py
+++ b/deepdiff/colored_view.py
@@ -109,11 +109,12 @@ class ColoredView:
             return '{\n' + ',\n'.join(items) + f'\n{current_indent}' + '}'
 
         elif isinstance(obj, (list, tuple)):
-            if not obj:
-                return '[]'
             removed_map = self._get_path_removed(path)
             for index in removed_map:
                 self._colorize_skip_paths.add(f"{path}[{index}]")
+
+            if not obj and not removed_map:
+                return '[]'
 
             items = []
             remove_index = 0

--- a/tests/test_colored_view.py
+++ b/tests/test_colored_view.py
@@ -117,6 +117,22 @@ def test_colored_view_list_deletions():
     assert result == expected
 
 
+def test_colored_view_list_all_removed():
+    """Test that removing all items from a list shows them in colored view."""
+    t1 = [1, 2, 3]
+    t2 = []
+
+    diff = DeepDiff(t1, t2, view=COLORED_VIEW)
+    result = str(diff)
+
+    expected = f'''[
+  {RED}1{RESET},
+  {RED}2{RESET},
+  {RED}3{RESET}
+]'''
+    assert result == expected
+
+
 def test_colored_view_list_additions():
     t1 = [2, 4]
     t2 = [1, 2, 3, 4, 5]


### PR DESCRIPTION
## Problem

When comparing a list with an empty list using `COLORED_VIEW`, all removed items are silently dropped from the output. The `str()` representation returns `[]` instead of showing the removed items.

### Reproduction

```python
from deepdiff.helper import COLORED_VIEW
from deepdiff import DeepDiff

t1 = [1, 2, 3]
t2 = []
print(DeepDiff(t1, t2, view=COLORED_VIEW))  # prints [] instead of showing removed items
```

## Root Cause

In `deepdiff/colored_view.py`, the list branch of `_colorize_json` checks `if not obj: return '[]'` **before** collecting removed items via `self._get_path_removed(path)`. When `t2` is empty, the function returns immediately without ever checking for removed items.

## Fix

Move the empty check after collecting `removed_map`, and only return `'[]'` if both the object is empty AND there are no removed items.

## Testing

- All 16 existing colored view tests continue to pass
- Added `test_colored_view_list_all_removed` to cover the empty list case

Fixes #575
