### PR TITLE
fix: skip time truncation for date objects in truncate_datetime

### DIFF
--- a/deepdiff/helper.py
+++ b/deepdiff/helper.py
@@ -690,7 +690,9 @@ def datetime_normalize(
         datetime.timezone, "BaseTzInfo"
     ] = datetime.timezone.utc,
 ) -> Any:
-    if truncate_datetime:
+    # A plain date has no time component, so truncation does not apply to it.
+    has_time = not (isinstance(obj, datetime.date) and not isinstance(obj, datetime.datetime))
+    if truncate_datetime and has_time:
         if truncate_datetime == 'second':
             obj = obj.replace(microsecond=0)
         elif truncate_datetime == 'minute':

--- a/tests/test_diff_other.py
+++ b/tests/test_diff_other.py
@@ -71,6 +71,15 @@ class TestDiffOther:
         res = DeepDiff(d1, d2, truncate_datetime='second')
         assert res['values_changed']["root['a']"]['new_value'] == 80139
 
+    def test_truncate_datetime_with_date(self):
+        d1 = {'a': datetime.date(2020, 5, 17)}
+        d2 = {'a': datetime.date(2020, 5, 17)}
+        assert DeepDiff(d1, d2, truncate_datetime='minute') == {}
+
+        d3 = {'a': datetime.date(2020, 5, 18)}
+        res = DeepDiff(d1, d3, truncate_datetime='day')
+        assert res['values_changed']["root['a']"]['new_value'] == datetime.date(2020, 5, 18)
+
     def test_invalid_verbose_level(self):
         with pytest.raises(ValueError) as excinfo:
             DeepDiff(1, 2, verbose_level=5)


### PR DESCRIPTION
Fixes #564.

`DeepDiff(..., truncate_datetime=...)` raised `TypeError: 'second' is an invalid keyword argument for replace()` when comparing `datetime.date` values, because `datetime_normalize` called `replace(second=0, ...)` on a plain date that has no time component.

A `datetime.date` (that is not a `datetime.datetime`) has no time fields, so time truncation is now skipped for it. `datetime` and `time` truncation are unchanged. Added a regression test.