### PR TITLE
Fix TypeError for datetime dict keys with key-cleaning flags (fixes #550)

### DIFF
--- a/deepdiff/helper.py
+++ b/deepdiff/helper.py
@@ -475,7 +475,12 @@ def number_to_string(number: Any, significant_digits: int, number_format_notatio
     except KeyError:
         raise ValueError("number_format_notation got invalid value of {}. The valid values are 'f' and 'e'".format(number_format_notation)) from None
 
-    if not isinstance(number, numbers):  # type: ignore
+    if not isinstance(number, only_numbers):  # type: ignore
+        # `numbers` also includes datetime types (they are orderable), but those
+        # cannot be reduced to significant digits via round(); leave any
+        # non-numeric value (datetimes, dates, etc.) unchanged. Otherwise using
+        # e.g. a datetime as a dict key together with ignore_numeric_type_changes
+        # raised "TypeError: type datetime.datetime doesn't define __round__".
         return number
     elif isinstance(number, Decimal):
         with localcontext() as ctx:

--- a/tests/test_diff_datetime.py
+++ b/tests/test_diff_datetime.py
@@ -123,3 +123,22 @@ class TestDiffDatetime:
         assert not DeepDiff(d1, d2)
         assert not DeepDiff(d1, d2, ignore_order=True)
         assert not DeepDiff(d1, d2, truncate_datetime='second')
+
+    def test_datetime_dict_key_with_ignore_flags(self):
+        # Using a datetime/date as a dict key together with flags that clean the
+        # keys (ignore_numeric_type_changes / ignore_string_case /
+        # ignore_string_type_changes) used to raise
+        # "TypeError: type datetime.datetime doesn't define __round__ method"
+        # because the keys were routed through number_to_string, which only
+        # handles real numbers.
+        dt = datetime(2020, 5, 17, 22, 15)
+        assert not DeepDiff({dt: 10.0}, {dt: 10}, ignore_numeric_type_changes=True)
+        # date objects (no time component) too
+        assert not DeepDiff(
+            {date(2020, 5, 17): 10.0},
+            {date(2020, 5, 17): 10},
+            ignore_numeric_type_changes=True,
+        )
+        # the other key-cleaning flags must not raise either
+        assert not DeepDiff({dt: 1}, {dt: 1}, ignore_string_case=True)
+        assert not DeepDiff({dt: 1}, {dt: 1}, ignore_string_type_changes=True)


### PR DESCRIPTION
### Summary

Using a `datetime`/`date` as a dict **key** together with one of the
key-cleaning flags raised a `TypeError`:

```python
import datetime
from deepdiff import DeepDiff

dt = datetime.datetime(2020, 5, 17, 22, 15)
DeepDiff({dt: 10.0}, {dt: 10}, ignore_numeric_type_changes=True)
# TypeError: type datetime.datetime doesn't define __round__ method
```

The same happens with `ignore_string_case` and `ignore_string_type_changes`
(any flag that routes dict keys through `_get_clean_to_keys_mapping`), and with
`datetime.date` keys.

### Root cause

`_get_clean_to_keys_mapping` cleans numeric keys via `number_to_string`, whose
type guard is:

```python
if not isinstance(number, numbers):
    return number
```

`numbers` is defined as `only_numbers + datetimes` (datetimes are included
because they are orderable). So a datetime key passes the guard and falls
through to `round(number, ndigits=significant_digits)`, which datetimes do not
implement → `TypeError`.

### Fix

Guard on `only_numbers` instead. Datetimes/dates (and anything else that is not
a real, round()-able number) are returned unchanged, exactly like every other
non-numeric value — which is what the early-return branch is for. Numeric
behaviour (int/float/Decimal/Fraction/complex/numpy, significant-digit
rounding) is unchanged.

### Verification

```python
dt = datetime.datetime(2020, 5, 17, 22, 15)
DeepDiff({dt: 10.0}, {dt: 10}, ignore_numeric_type_changes=True)   # {}  (was TypeError)
```

Added `test_datetime_dict_key_with_ignore_flags` to
`tests/test_diff_datetime.py`. It fails on `dev`
(`TypeError ... __round__`) and passes with this change. The existing
`tests/test_diff_datetime.py` and `tests/test_helper.py` suites (168 tests)
still pass.

Fixes #550.
