### PR TITLE
Fix typos in docstrings and comments

### DIFF
--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -1094,7 +1094,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, DeepDiffProtocol, 
         opcodes = seq.get_opcodes()
         opcodes_with_values = []
 
-        # TODO: this logic should be revisted so we detect reverse operations
+        # TODO: this logic should be revisited so we detect reverse operations
         # like when a replacement happens at index X and a reverse replacement happens at index Y
         # in those cases we have a "iterable_item_moved" operation.
         for tag, t1_from_index, t1_to_index, t2_from_index, t2_to_index in opcodes:

--- a/deepdiff/docstrings/deephash_doc.rst
+++ b/deepdiff/docstrings/deephash_doc.rst
@@ -92,7 +92,7 @@ ignore_type_in_groups
     1. Set ignore_string_type_changes=True which is the default.
     2. Set ignore_type_in_groups=[(str, bytes)]. Here you are saying if we detect one type to be str and the other one bytes, do not report them as type change. It is exactly as passing ignore_type_in_groups=[DeepDiff.strings] or ignore_type_in_groups=DeepDiff.strings .
 
-    Now what if you want also typeA and typeB to be ignored when comparing agains each other?
+    Now what if you want also typeA and typeB to be ignored when comparing against each other?
 
     1. ignore_type_in_groups=[DeepDiff.strings, (typeA, typeB)]
     2. or ignore_type_in_groups=[(str, bytes), (typeA, typeB)]

--- a/deepdiff/docstrings/view.rst
+++ b/deepdiff/docstrings/view.rst
@@ -76,7 +76,7 @@ You can traverse through the tree elements!
 :repetition: Shortcut to get the repetition report
 
 
-The tree view allows you to have more than mere textual representaion of the diffed objects.
+The tree view allows you to have more than mere textual representation of the diffed objects.
 It gives you the actual objects (t1, t2) throughout the tree of parents and children.
 
 **Examples for Tree View**
@@ -199,7 +199,7 @@ List difference ignoring order but reporting repetitions (Tree View)
     <root[0]>
     >>>
     >>> # But the verbosity level does not change the actual report object.
-    >>> # It only changes the textual representaion of the object. We get the actual object here:
+    >>> # It only changes the textual representation of the object. We get the actual object here:
     >>> repeat1.repetition
     {'old_repeat': 1, 'new_repeat': 2, 'old_indexes': [3], 'new_indexes': [0, 1]}
     >>> repeat1.t1

--- a/deepdiff/model.py
+++ b/deepdiff/model.py
@@ -817,7 +817,7 @@ class DiffLevel:
 
     def copy(self) -> 'DiffLevel':
         """
-        Get a deep copy of this comparision line.
+        Get a deep copy of this comparison line.
         :return: The leaf ("downmost") object of the copy.
         """
         orig = self.all_up


### PR DESCRIPTION
A few small typo fixes I came across while reading through the code and docs:

- `deepdiff/model.py` - "comparision" -> "comparison" (in `DiffLevel.copy` docstring)
- `deepdiff/diff.py` - "revisted" -> "revisited" (TODO comment)
- `deepdiff/docstrings/view.rst` - "representaion" -> "representation" (x2, these render in the docs)
- `deepdiff/docstrings/deephash_doc.rst` - "agains" -> "against"

Comments and documentation only - no functional changes. Branched off `dev`.