### PR TITLE
fix: truncate_datetime no longer crashes on date objects (#564)

### DIFF
--- a/deepdiff/helper.py
+++ b/deepdiff/helper.py
@@ -685,12 +685,15 @@ def time_to_seconds(t: datetime.time) -> int:
 
 def datetime_normalize(
     truncate_datetime:Union[str, None],
-    obj:Union[datetime.datetime, datetime.time],
+    obj:Union[datetime.datetime, datetime.date, datetime.time],
     default_timezone: Union[
         datetime.timezone, "BaseTzInfo"
     ] = datetime.timezone.utc,
 ) -> Any:
-    if truncate_datetime:
+    # A pure date has no time component, so truncation does not apply to it
+    # (and date.replace() does not accept hour/minute/second/microsecond).
+    # datetime is a subclass of date, so target datetime/time explicitly.
+    if truncate_datetime and isinstance(obj, (datetime.datetime, datetime.time)):
         if truncate_datetime == 'second':
             obj = obj.replace(microsecond=0)
         elif truncate_datetime == 'minute':

--- a/tests/test_diff_datetime.py
+++ b/tests/test_diff_datetime.py
@@ -52,6 +52,27 @@ class TestDiffDatetime:
         }
         assert res == expected
 
+    def test_truncate_datetime_with_date(self):
+        # truncate_datetime used to crash on date objects because a date has no
+        # time component and date.replace() rejects second/microsecond kwargs.
+        d1 = {"a": date(2020, 5, 17)}
+        d2 = {"a": date(2020, 5, 17)}
+        for truncate in ("second", "minute", "hour", "day"):
+            assert DeepDiff(d1, d2, truncate_datetime=truncate) == {}
+
+        d1 = {"a": date(2020, 5, 17)}
+        d2 = {"a": date(2020, 5, 18)}
+        res = DeepDiff(d1, d2, truncate_datetime="minute")
+        expected = {
+            "values_changed": {
+                "root['a']": {
+                    "new_value": date(2020, 5, 18),
+                    "old_value": date(2020, 5, 17),
+                }
+            }
+        }
+        assert res == expected
+
     def test_time_diff(self):
         """Testing for the correct setting and usage of epsilon."""
         d1 = {"a": time(10, 11, 12)}


### PR DESCRIPTION
Fixes #564.

## Problem
`truncate_datetime` crashes with `TypeError: 'second' is an invalid keyword argument for replace()` when a value is a `datetime.date` (not a `datetime.datetime`):

```python
import datetime
from deepdiff import DeepDiff
DeepDiff({'a': datetime.date(2020, 5, 17)},
         {'a': datetime.date(2020, 5, 17)},
         truncate_datetime='minute')   # TypeError
```

A pure `date` is dispatched to `_diff_time` → `datetime_normalize`, which calls `obj.replace(second=0, microsecond=0)`. `date.replace()` only accepts `year`/`month`/`day`, so it raises.

## Fix
A `date` has no time component, so truncation does not apply to it. Guard the truncation block to run only on objects that actually have a time component (`datetime` / `time`). `datetime` is a subclass of `date`, so the `isinstance` targets `datetime`/`time` explicitly and leaves pure dates untouched (they then fall through and are returned unchanged, so equal dates compare equal and differing dates still diff).

The change is one line of logic plus a clarifying comment; the type annotation is widened to include `datetime.date`.

## Tests
Added `test_truncate_datetime_with_date` to `tests/test_diff_datetime.py`. It is proven to bite: it fails on the unpatched source (the original `TypeError`) and passes with the fix. The existing datetime/group_by/math suites continue to pass.
