### PR TITLE
Fix Delta dropping a replaced set element when old and new hash-collide

### DIFF
--- a/deepdiff/delta.py
+++ b/deepdiff/delta.py
@@ -181,8 +181,13 @@ class Delta:
             self.root = deepcopy(other)
         self._do_pre_process()
         self._do_values_changed()
-        self._do_set_item_added()
+        # NOTE: set removals must happen BEFORE set additions. When a removed
+        # element is equal to and hashes equal to an added element (e.g. False
+        # and 0), adding first lets ``set.union`` keep the existing member, so
+        # the new element is never inserted and the later removal drops it --
+        # mirroring the reverse order of operations used for iterables below.
         self._do_set_item_removed()
+        self._do_set_item_added()
         self._do_type_changes()
         # NOTE: the remove iterable action needs to happen BEFORE
         # all the other iterables to match the reverse of order of operations in DeepDiff

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -1858,6 +1858,20 @@ class TestDeltaOther:
         delta_again = Delta(flat_rows_list=flat_expected)
         assert delta.diff == delta_again.diff
 
+    @pytest.mark.parametrize('t1, t2', [
+        ({False}, {0}),
+        ({0}, {False}),
+        ({1.0}, {1}),
+        ({False, 100}, {0, 'x'}),
+    ])
+    def test_delta_set_replace_equal_hashing_member(self, t1, t2):
+        # When a removed set element is equal to and hashes equal to an added
+        # one (e.g. False/0, 1.0/1), applying the Delta must still round-trip.
+        # Additions used to run before removals, so set.union kept the old
+        # member and the new element was dropped, leaving an empty/short set.
+        delta = Delta(DeepDiff(t1, t2))
+        assert t1 + delta == t2
+
     def test_delta_array_of_bytes(self):
         t1 = []
         t2 = [b"hello"]


### PR DESCRIPTION
## Summary

Applying a `Delta` that replaces a set element drops the element when the new value is equal to and hashes equal to the removed one — breaking the round-trip `t1 + Delta(DeepDiff(t1, t2)) == t2`:

```python
from deepdiff import DeepDiff, Delta
t1, t2 = {False}, {0}
t1 + Delta(DeepDiff(t1, t2))   # -> set()   (expected {0})
```

Also reproduces for `{0} -> {False}`, `{1.0} -> {1}`, and mixed sets like `{False, 100} -> {0, 'x'}` (drops the `0`). `DeepDiff` itself is correct here — it emits `set_item_removed` for the old element and `set_item_added` for the new one; only the Delta *application* is wrong.

## Cause

`Delta.__add__` applied set additions **before** removals:

```python
self._do_set_item_added()
self._do_set_item_removed()
```

`_do_set_item_added` does `current.union({new})`. Because `False == 0` and they hash equally, `{False}.union({0})` keeps the existing `False` and never inserts `0`. `_do_set_item_removed` then removes `False`, leaving `set()`.

Set add/remove are only order-independent when the values don't collide. The file already documents this exact "remove before add" principle for iterables a few lines below, but it wasn't applied to sets.

## Fix

Swap the two calls so removals run first (with a NOTE mirroring the existing iterable comment). With the colliding old element removed first, `union` inserts the new element cleanly.

Verified across `False`/`0`, `1.0`/`1`, and mixed-set cases; added a parametrized regression test (`test_delta_set_replace_equal_hashing_member`). `tests/test_delta.py`: 130 passed; the 2 remaining failures (`test_delta_repr`, `test_list_of_alphabet_and_its_delta`) are pre-existing and reproduce on a clean `dev` tree (an `orderly-set` `Opcode` signature change and a repr-format diff), unrelated to this change.

Found by fuzzing the `Delta` apply round-trip. This pull request was prepared with the assistance of AI, under my direction and review.
