### PR TITLE
fix: avoid ValueError/OverflowError on NaN/Inf with significant_digits=0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 9.0.0
+current_version = 9.1.0
 commit = False
 tag = False
 tag_name = {new_version}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,6 @@ authors:
   given-names: "Sep"
   orcid: "https://orcid.org/0009-0009-5828-4345"
 title: "DeepDiff"
-version: 9.0.0
+version: 9.1.0
 date-released: 2026
 url: "https://github.com/seperman/deepdiff"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DeepDiff v 9.1.0
+# DeepDiff v 9.0.0
 
 ![Downloads](https://img.shields.io/pypi/dm/deepdiff.svg?style=flat)
 ![Python Versions](https://img.shields.io/pypi/pyversions/deepdiff.svg?style=flat)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DeepDiff v 9.0.0
+# DeepDiff v 9.1.0
 
 ![Downloads](https://img.shields.io/pypi/dm/deepdiff.svg?style=flat)
 ![Python Versions](https://img.shields.io/pypi/pyversions/deepdiff.svg?style=flat)

--- a/deepdiff/__init__.py
+++ b/deepdiff/__init__.py
@@ -1,6 +1,6 @@
 """This module offers the DeepDiff, DeepSearch, grep, Delta and DeepHash classes."""
 # flake8: noqa
-__version__ = '9.0.0'
+__version__ = '9.1.0'
 import logging
 
 if __name__ == '__main__':

--- a/deepdiff/docstrings/index.rst
+++ b/deepdiff/docstrings/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 
-DeepDiff 9.0.0 documentation!
+DeepDiff 9.1.0 documentation!
 =============================
 
 .. |qluster_link| raw:: html

--- a/deepdiff/helper.py
+++ b/deepdiff/helper.py
@@ -1,6 +1,7 @@
 import sys
 import re
 import os
+import math
 import datetime
 import uuid
 import logging
@@ -513,7 +514,7 @@ def number_to_string(number: Any, significant_digits: int, number_format_notatio
     else:
         number = round(number=number, ndigits=significant_digits)  # type: ignore
 
-        if significant_digits == 0:
+        if significant_digits == 0 and math.isfinite(number):  # type: ignore
             number = int(number)  # type: ignore
 
     if number == 0.0:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,9 +64,9 @@ author = 'Sep Dehpour'
 # built documents.
 #
 # The short X.Y version.
-version = '9.0.0'
+version = '9.1.0'
 # The full version, including alpha/beta/rc tags.
-release = '9.0.0'
+release = '9.1.0'
 
 load_dotenv(override=True)
 DOC_VERSION = os.environ.get('DOC_VERSION', version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "deepdiff"
-version = "9.0.0"
+version = "9.1.0"
 dependencies = [
   "cachebox>=5.2,<6",
   "orderly-set>=5.5.0,<6",

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -1877,6 +1877,29 @@ class TestDeepDiffText:
     def test_ignore_nan_inequality(self, t1, t2, params, expected_result):
         assert expected_result == list(DeepDiff(t1, t2, **params).keys())
 
+    @pytest.mark.parametrize('t1, t2, params', [
+        (float('nan'), float('nan'), {'significant_digits': 0}),
+        (float('nan'), float('nan'), {'significant_digits': 2}),
+        (float('inf'), float('inf'), {'significant_digits': 0}),
+        (float('inf'), float('inf'), {'significant_digits': 2}),
+        (float('-inf'), float('-inf'), {'significant_digits': 0}),
+        (float('-inf'), float('-inf'), {'significant_digits': 2}),
+        ({'a': float('nan'), 'b': 1.5}, {'a': float('nan'), 'b': 2.7},
+         {'significant_digits': 0}),
+        ({'a': float('inf')}, {'a': float('inf')},
+         {'significant_digits': 0}),
+    ])
+    def test_significant_digits_with_nan_inf(self, t1, t2, params):
+        """
+        Test that significant_digits does not crash with NaN or Inf values.
+        Regression test for ValueError/OverflowError when converting NaN/Inf
+        to int in number_to_string with significant_digits=0.
+        """
+        try:
+            DeepDiff(t1, t2, **params)
+        except (ValueError, OverflowError) as e:
+            pytest.fail(f"DeepDiff with {params} on {t1!r} raised {type(e).__name__}: {e}")
+
     @pytest.mark.parametrize('ignore_order, ignore_private_variables, expected', [
         (True, True, {}),
         (False, True, {}),


### PR DESCRIPTION
## Problem

`DeepDiff` crashes with `ValueError` or `OverflowError` when comparing NaN or Inf float values with `significant_digits=0`:

```python
>>> from deepdiff import DeepDiff
>>> DeepDiff(float('nan'), float('nan'), significant_digits=0)
ValueError: cannot convert float NaN to integer

>>> DeepDiff(float('inf'), float('inf'), significant_digits=0)
OverflowError: cannot convert float infinity to integer
```

The crash also occurs when NaN/Inf values are nested inside dicts, lists, or other structures.

## Root Cause

In `number_to_string`, when `significant_digits=0`, the code calls `int(number)` on the rounded value. For NaN and Inf, `round()` returns NaN/Inf unchanged, and `int()` raises because these values cannot be converted to integers.

## Fix

Guard the `int()` conversion with `math.isfinite()` so that NaN and Inf values pass through without attempting integer conversion. Their string representations ("nan", "inf", "-inf") will compare correctly in the existing string-comparison path.

The fix is a one-line change: `if significant_digits == 0` becomes `if significant_digits == 0 and math.isfinite(number)`.

## Additional Note

When `significant_digits > 0`, NaN and Inf do not crash because `round(nan, n)` returns NaN and the string formatting produces "nan" which compares equal to another "nan". This behavior is preserved.