### PR TITLE
Fix missing type changes for equal-comparing list items (#605)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -88,3 +88,4 @@ Authors in order of the timeline of their contributions:
 - [akshat62](https://github.com/akshat62) for adding Fraction numeric support.
 - [akshat62](https://github.com/akshat62) for adding wildcard/glob pattern support for `exclude_paths` and `include_paths`.
 - [mgorny](https://github.com/mgorny) for adding missing files to sdist and removing obsolete `MANIFEST.in`.
+- [Sanjays2402](https://github.com/Sanjays2402) for fixing missing type changes between equal-comparing list items (e.g. `[2]` vs `[2.0]`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # DeepDiff Change log
 
+- Unreleased
+    - Fixed missing type changes between equal-comparing items inside ordered iterables, e.g. `DeepDiff([2], [2.0])` now reports the `int` → `float` change like `DeepDiff(2, 2.0)` and `DeepDiff({'a': 2}, {'a': 2.0})` already do (issue #605).
+
 - v9-1-0
     - Added multiprocessing support for DeepDiff: parallel distance computation and parallel subtree diffing with aggregated worker stats, deterministic ordering, and automatic fallback to serial when unsafe (e.g. `custom_operators`, `*_obj_callback`, `ignore_order_func`)
     - Added wildcard/glob pattern support for `exclude_paths` and `include_paths` thanks to [akshat62](https://github.com/akshat62)

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -1102,6 +1102,22 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, DeepDiffProtocol, 
                 opcodes_with_values.append(Opcode(
                     tag, t1_from_index, t1_to_index, t2_from_index, t2_to_index,
                 ))
+                # SequenceMatcher considers items "equal" when they compare equal
+                # (e.g. 2 == 2.0), even when their types differ. Recurse into _diff
+                # for such pairs so that type changes are reported for iterable items
+                # the same way they are for scalars and dict values (issue #605).
+                for index in range(t1_to_index - t1_from_index):
+                    x = level.t1[t1_from_index + index]
+                    y = level.t2[t2_from_index + index]
+                    if get_type(x) != get_type(y):
+                        change_level = level.branch_deeper(
+                            x,
+                            y,
+                            child_relationship_class=child_relationship_class,
+                            child_relationship_param=index + t1_from_index,
+                            child_relationship_param2=index + t2_from_index,
+                        )
+                        self._diff(change_level, parents_ids, local_tree=local_tree)
                 continue
             # print('{:7}   t1[{}:{}] --> t2[{}:{}] {!r:>8} --> {!r}'.format(
             #     tag, t1_from_index, t1_to_index, t2_from_index, t2_to_index, level.t1[t1_from_index:t1_to_index], level.t2[t2_from_index:t2_to_index]))

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -64,6 +64,51 @@ class TestDeepDiffText:
                 }
                 }} == DeepDiff(t1, t2, verbose_level=0)
 
+    def test_item_type_change_in_list(self):
+        """A type change between two equal-comparing items (e.g. 2 and 2.0)
+        inside a list must be reported, consistently with scalars and dicts.
+
+        SequenceMatcher considers 2 == 2.0 "equal", which used to make the
+        difference disappear entirely for lists while DeepDiff(2, 2.0) and
+        DeepDiff({'a': 2}, {'a': 2.0}) both reported a type change (issue #605).
+        """
+        t1 = [2]
+        t2 = [2.0]
+        ddiff = DeepDiff(t1, t2)
+        assert {
+            'type_changes': {
+                "root[0]": {
+                    "old_value": 2,
+                    "old_type": int,
+                    "new_value": 2.0,
+                    "new_type": float
+                }
+            }
+        } == ddiff
+        # consistent with the scalar and dict equivalents
+        assert ddiff['type_changes']["root[0]"]["old_type"] is \
+            DeepDiff(2, 2.0)['type_changes']["root"]["old_type"]
+
+    def test_item_type_change_in_list_among_unchanged_items(self):
+        t1 = [1, 2, 3]
+        t2 = [1, 2.0, 3]
+        ddiff = DeepDiff(t1, t2)
+        assert {
+            'type_changes': {
+                "root[1]": {
+                    "old_value": 2,
+                    "old_type": int,
+                    "new_value": 2.0,
+                    "new_type": float
+                }
+            }
+        } == ddiff
+
+    def test_item_type_change_in_list_ignored_when_requested(self):
+        t1 = [2]
+        t2 = [2.0]
+        assert DeepDiff(t1, t2, ignore_numeric_type_changes=True) == {}
+
     def test_item_type_change_for_strings_ignored_by_default(self):
         """ ignore_string_type_changes = True by default """
 


### PR DESCRIPTION
Fixes #605

## The bug

`DeepDiff([2], [2.0])` reports **no difference at all**, even though the scalar and dict equivalents both correctly report an `int` → `float` type change:

```python
>>> from deepdiff import DeepDiff
>>> DeepDiff(2, 2.0)
{'type_changes': {'root': {'old_type': int, 'new_type': float, 'old_value': 2, 'new_value': 2.0}}}
>>> DeepDiff({'a': 2}, {'a': 2.0})
{'type_changes': {"root['a']": {'old_type': int, 'new_type': float, ...}}}
>>> DeepDiff([2], [2.0])      # ← inconsistent
{}
```

The same silent miss affects any equal-but-differently-typed pair inside a list, and changes buried among unchanged items:

```python
>>> DeepDiff([1, 2, 3], [1, 2.0, 3])   # {}  (expected type_change at root[1])
>>> DeepDiff([1], [Decimal(1)])        # {}
>>> DeepDiff([True], [1])              # {}
```

## Root cause

For ordered iterables whose items are all basic-hashable, `_diff_iterable_in_order` diffs the two sequences with `difflib.SequenceMatcher`. Because `2 == 2.0` (and `hash(2) == hash(2.0)`), `SequenceMatcher` classifies the pair as an **`'equal'`** opcode:

```python
>>> import difflib
>>> difflib.SequenceMatcher(None, [2], [2.0], autojunk=False).get_opcodes()
[('equal', 0, 1, 0, 1)]
```

The `'equal'` branch in `_diff_ordered_iterable_by_difflib` recorded the opcode and `continue`d — the items were **never handed to `_diff()`**, which is the only place the type-change check `get_type(t1) != get_type(t2)` lives. So the difference vanished. Scalars and dict values go through `_diff()` directly, which is why they behave correctly.

This is the ordered-diff complement of the `ignore_order=True` int-vs-float fix already noted in the v9.0.0 changelog.

## The fix

In the `'equal'` opcode branch, recurse into `_diff()` for any aligned pair whose types differ:

```python
if tag == 'equal':
    opcodes_with_values.append(Opcode(...))
    for index in range(t1_to_index - t1_from_index):
        x = level.t1[t1_from_index + index]
        y = level.t2[t2_from_index + index]
        if get_type(x) != get_type(y):
            change_level = level.branch_deeper(x, y, ...)
            self._diff(change_level, parents_ids, local_tree=local_tree)
    continue
```

Routing through `_diff()` reuses the existing type-change machinery, so every option is honored automatically — no duplicated logic.

## Before / after

| Input | Before | After |
|-------|--------|-------|
| `DeepDiff([2], [2.0])` | `{}` | `type_changes root[0]: int→float` |
| `DeepDiff([1,2,3], [1,2.0,3])` | `{}` | `type_changes root[1]: int→float` |
| `DeepDiff([1], [Decimal(1)])` | `{}` | `type_changes root[0]: int→Decimal` |
| `DeepDiff([2], [2.0], ignore_numeric_type_changes=True)` | `{}` | `{}` (unchanged — correctly suppressed) |
| `DeepDiff([2], [2])` | `{}` | `{}` (unchanged — no over-reporting) |

## Tests

Added three regression tests in `tests/test_diff_text.py` (repo style):

- `test_item_type_change_in_list` — `[2]` vs `[2.0]` reports the change and asserts it matches the scalar result
- `test_item_type_change_in_list_among_unchanged_items` — `[1,2,3]` vs `[1,2.0,3]`
- `test_item_type_change_in_list_ignored_when_requested` — `ignore_numeric_type_changes=True` still yields `{}`

Proof they guard the bug: with the source change stashed, the two positive tests **FAIL**; restored, all three **PASS**.

Full suite unchanged from baseline: **1251 passed, 44 skipped** (the only failures locally are missing-optional-dep / macOS `setrlimit` env artifacts, identical with and without this change).
