### PR TITLE
Fix mangled __slots__ attribute lost for subclass instances (#506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # DeepDiff Change log
 
 - v9-1-0
+    - Fixed `_dict_from_slots` dropping a parent-declared mangled `__slots__` attribute for a subclass instance, because the name was unmangled using the concrete instance type instead of the declaring class (#506)
     - Added multiprocessing support for DeepDiff: parallel distance computation and parallel subtree diffing with aggregated worker stats, deterministic ordering, and automatic fallback to serial when unsafe (e.g. `custom_operators`, `*_obj_callback`, `ignore_order_func`)
     - Added wildcard/glob pattern support for `exclude_paths` and `include_paths` thanks to [akshat62](https://github.com/akshat62)
     - Reimplemented internal cache for improved performance

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -503,10 +503,13 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, DeepDiffProtocol, 
 
     @staticmethod
     def _dict_from_slots(object: Any) -> Dict[str, Any]:
-        def unmangle(attribute: str) -> str:
+        def unmangle(attribute: str, klass: type) -> str:
+            # A mangled slot (e.g. ``__id``) is stored under the name of the
+            # class that declared it, not the concrete instance type, so a
+            # subclass instance would otherwise lose a parent-defined slot (#506).
             if attribute.startswith('__') and attribute != '__weakref__':
                 return '_{type}{attribute}'.format(
-                    type=type(object).__name__,
+                    type=klass.__name__,
                     attribute=attribute
                 )
             return attribute
@@ -522,11 +525,15 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, DeepDiffProtocol, 
             slots = getattr(type_in_mro, '__slots__', None)
             if slots:
                 if isinstance(slots, strings):
-                    all_slots.append(slots)
+                    all_slots.append((type_in_mro, slots))
                 else:
-                    all_slots.extend(slots)
+                    all_slots.extend((type_in_mro, i) for i in slots)
 
-        return {i: getattr(object, key) for i in all_slots if hasattr(object, key := unmangle(i))}
+        return {
+            i: getattr(object, key)
+            for (klass, i) in all_slots
+            if hasattr(object, key := unmangle(i, klass))
+        }
 
     def _diff_enum(self, level: Any, parents_ids: FrozenSet[int]=frozenset(), local_tree: Optional[Any]=None) -> None:
         t1 = detailed__dict__(level.t1, include_keys=ENUM_INCLUDE_KEYS)

--- a/tests/test_diff_text.py
+++ b/tests/test_diff_text.py
@@ -823,6 +823,22 @@ class TestDeepDiffText:
         result = {}
         assert result == ddiff
 
+    def test_dict_from_slots_of_subclass_with_mangled_attribute(self):
+        # A mangled slot (e.g. ``__id``) declared on a parent class is stored
+        # under the parent's mangled name, so it must be unmangled using the
+        # declaring class, not the concrete instance type. Otherwise a subclass
+        # instance silently loses the parent-defined slot. See #506.
+        class ClassA:
+            __slots__ = ('__id',)
+
+            def __init__(self, id):
+                self.__id = id
+
+        class ClassB(ClassA):
+            pass
+
+        assert DeepDiff._dict_from_slots(ClassA(5)) == {'__id': 5}
+        assert DeepDiff._dict_from_slots(ClassB(5)) == {'__id': 5}
 
     def test_custom_class_changes_none_when_ignore_type(self):
         ddiff1 = DeepDiff({'a': None}, {'a': 1}, ignore_type_subclasses=True, ignore_type_in_groups=[(int, float)])


### PR DESCRIPTION
## Summary

Closes #506.

`_dict_from_slots` unmangled each slot name using the **concrete instance type**:

```python
def unmangle(attribute):
    if attribute.startswith('__') and attribute != '__weakref__':
        return '_{type}{attribute}'.format(type=type(object).__name__, attribute=attribute)
    ...
```

A mangled slot such as `__id` is stored under the name of the class that **declared** it (e.g. `_Parent__id`). For a subclass instance, `type(object).__name__` is the subclass, so the lookup used the wrong name (`_Child__id`), `hasattr(...)` returned `False`, and the parent-defined slot was silently dropped:

```python
class A:
    __slots__ = ('__id',)
    def __init__(self, id): self.__id = id

class B(A):
    pass

DeepDiff._dict_from_slots(A(5))   # {'__id': 5}
DeepDiff._dict_from_slots(B(5))   # {}   <-- parent slot lost
```

This is the root cause behind the `unprocessed` / dropped-attribute behavior reported when comparing an instance of a class with an instance of its subclass where a slot uses a mangled (dunder-prefixed) attribute — e.g. `bson.ObjectId` vs a subclass of it.

## Fix

Pair each slot with the class in the MRO that declared it, and unmangle using that class's name. Non-mangled slots are unaffected.

## Tests

Added `test_dict_from_slots_of_subclass_with_mangled_attribute`, asserting the parent-declared mangled slot is collected for both the base and the subclass instance. It fails on `master` (`{}` for the subclass) and passes with this change. The existing slots tests still pass; `flake8` introduces no new warnings; added a CHANGELOG entry.