### PR TITLE
Add path-scoped JSON collection strategies

### DIFF
--- a/deepdiff/__init__.py
+++ b/deepdiff/__init__.py
@@ -12,3 +12,12 @@ from .search import DeepSearch as DeepSearch, grep as grep
 from .deephash import DeepHash as DeepHash
 from .delta import Delta as Delta
 from .path import extract as extract, parse_path as parse_path
+from .json_diff import (
+    CollectionStrategy as CollectionStrategy,
+    CollectionStrategyError as CollectionStrategyError,
+    DeepJSONDiff as DeepJSONDiff,
+    DuplicateIdentityError as DuplicateIdentityError,
+    DuplicateIdentityPolicy as DuplicateIdentityPolicy,
+    IdentityExtractionError as IdentityExtractionError,
+    MissingIdentityPolicy as MissingIdentityPolicy,
+)

--- a/deepdiff/docstrings/index.rst
+++ b/deepdiff/docstrings/index.rst
@@ -26,11 +26,13 @@ The DeepDiff library includes the following modules:
 
     It returns the deep difference of python objects. It can also be used to take the distance between objects. :doc:`/deep_distance`
 
+- **DeepJSONDiff** For opt-in, path-scoped comparison of JSON collections using identity matching, sorting, filtering, normalization, and explicit duplicate or missing-identity policies. :doc:`/json_collection_strategies`
+
 - **DeepSearch** Search for objects within other objects. :doc:`/dsearch`
 
-- **DeepHash** Hash any object based on their content even if they are not "hashable" in Python's eyes.  :doc:`/deephash`
+- **DeepHash** Hash any object based on their content even if they are not "hashable" in Python's eyes. :doc:`/deephash`
 
-- **Delta** Delta of objects that can be applied to other objects. Imagine git commits but for structured data.  :doc:`/delta`
+- **Delta** Delta of objects that can be applied to other objects. Imagine git commits but for structured data. :doc:`/delta`
 
 - **Extract** For extracting a path from an object  :doc:`/extract`
 
@@ -39,6 +41,11 @@ The DeepDiff library includes the following modules:
 ***********
 What Is New
 ***********
+
+Unreleased
+----------
+
+   - Added the opt-in ``DeepJSONDiff`` facade and ``CollectionStrategy`` API for path-scoped JSON collection matching, sorting, filtering, normalization, diagnostics, and explicit missing or duplicate identity policies.
 
 DeepDiff 9-0-0
 --------------
@@ -65,8 +72,7 @@ Tutorials
 *********
 
 Tutorials can be found on `Zepworks blog <https://zepworks.com/tags/deepdiff/>`_
-                                                                                                                                                                                                          
-
+                                                                                                                                                                                                           
 ************
 Installation
 ************
@@ -91,6 +97,7 @@ Importing
 .. code:: python
 
     >>> from deepdiff import DeepDiff  # For Deep Difference of 2 objects
+    >>> from deepdiff import DeepJSONDiff, CollectionStrategy  # For path-scoped JSON collection comparison
     >>> from deepdiff import grep, DeepSearch  # For finding if item exists in an object
     >>> from deepdiff import DeepHash  # For hashing objects based on their contents
     >>> from deepdiff import Delta  # For creating delta of objects that can be applied later to other objects.
@@ -142,6 +149,7 @@ References
    :maxdepth: 4
 
    diff
+   json_collection_strategies
    dsearch
    deephash
    delta

--- a/deepdiff/json_diff.py
+++ b/deepdiff/json_diff.py
@@ -1,0 +1,627 @@
+"""Path-scoped JSON comparison strategies built on top of :class:`DeepDiff`.
+
+The API is opt-in. ``DeepJSONDiff`` creates canonical, caller-isolated views of
+JSON-like inputs and delegates the final recursive comparison to ``DeepDiff``.
+"""
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterator, Mapping as MappingABC
+from copy import deepcopy
+from dataclasses import dataclass, field
+from enum import Enum
+import json
+import math
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from .diff import DeepDiff
+
+
+_MISSING = object()
+_ARRAY_WILDCARD = object()
+_KEY_WILDCARD = object()
+
+JSONScalar = Optional[bool | int | float | str]
+FilterFunc = Callable[[Any], bool]
+Normalizer = Callable[[Any], Any]
+PathToken = str | int | object
+SortKey = Tuple[Any, ...]
+
+_UNSAFE_DEEPDIFF_KWARGS = {
+    "include_paths",
+    "exclude_paths",
+    "exclude_regex_paths",
+    "ignore_order_func",
+    "iterable_compare_func",
+    "custom_operators",
+    "exclude_obj_callback",
+    "exclude_obj_callback_strict",
+}
+
+
+class MissingIdentityPolicy(str, Enum):
+    """Behaviour when an item does not contain all configured identity fields."""
+
+    ERROR = "error"
+    FALLBACK = "fallback"
+    EXCLUDE = "exclude"
+
+
+class DuplicateIdentityPolicy(str, Enum):
+    """Behaviour when multiple items produce the same identity."""
+
+    ERROR = "error"
+    GROUP = "group"
+
+
+class CollectionStrategyError(ValueError):
+    """Base error for invalid collection strategy configuration or execution."""
+
+
+class IdentityExtractionError(CollectionStrategyError):
+    """Raised when a required identity field cannot be extracted."""
+
+
+class DuplicateIdentityError(CollectionStrategyError):
+    """Raised when an identity expected to be unique is duplicated."""
+
+
+def _as_non_empty_string_tuple(value: Any, field_name: str) -> Tuple[str, ...]:
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise CollectionStrategyError(f"{field_name} must be a sequence of non-empty strings")
+    result = tuple(value)
+    if any(not isinstance(item, str) or not item for item in result):
+        raise CollectionStrategyError(f"{field_name} must contain only non-empty strings")
+    return result
+
+
+def _parse_quoted_key(token: str, pattern: str) -> str:
+    try:
+        value = ast.literal_eval(token)
+    except (SyntaxError, ValueError) as exc:
+        raise CollectionStrategyError(f"invalid quoted key selector in {pattern!r}") from exc
+    if not isinstance(value, str):
+        raise CollectionStrategyError(f"quoted key selector in {pattern!r} must contain a string")
+    return value
+
+
+def _parse_pattern(pattern: str) -> Tuple[PathToken, ...]:
+    """Parse the supported JSONPath-like collection selector into path tokens."""
+    if not isinstance(pattern, str) or not pattern.startswith("$"):
+        raise CollectionStrategyError("strategy path must be a string starting with '$'")
+    if pattern == "$":
+        return ()
+
+    tokens: List[PathToken] = []
+    index = 1
+    while index < len(pattern):
+        if pattern[index] == ".":
+            index += 1
+            start = index
+            while index < len(pattern) and pattern[index] not in ".[":
+                index += 1
+            token = pattern[start:index]
+            if not token:
+                raise CollectionStrategyError(f"invalid strategy path {pattern!r}")
+            tokens.append(_KEY_WILDCARD if token == "*" else token)
+            continue
+
+        if pattern[index] == "[":
+            close = index + 1
+            quote: Optional[str] = None
+            escaped = False
+            while close < len(pattern):
+                char = pattern[close]
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif quote is not None:
+                    if char == quote:
+                        quote = None
+                elif char in ("'", '"'):
+                    quote = char
+                elif char == "]":
+                    break
+                close += 1
+            if close >= len(pattern) or pattern[close] != "]" or quote is not None:
+                raise CollectionStrategyError(f"invalid strategy path {pattern!r}")
+
+            token = pattern[index + 1 : close]
+            if token == "*":
+                tokens.append(_ARRAY_WILDCARD)
+            elif token.isdigit():
+                tokens.append(int(token))
+            elif len(token) >= 2 and token[0] in ("'", '"') and token[-1] == token[0]:
+                tokens.append(_parse_quoted_key(token, pattern))
+            else:
+                raise CollectionStrategyError(
+                    "bracket selectors must contain an integer index, '*', or a quoted key"
+                )
+            index = close + 1
+            continue
+
+        raise CollectionStrategyError(f"invalid strategy path {pattern!r}")
+
+    return tuple(tokens)
+
+
+@dataclass(frozen=True)
+class CollectionStrategy:
+    """Rules applied to a JSON array selected by ``path``."""
+
+    path: str
+    match_by: Tuple[str, ...] = ()
+    sort_by: Tuple[str, ...] = ()
+    filter_func: Optional[FilterFunc] = None
+    normalizers: Tuple[Normalizer, ...] = ()
+    exclude_fields: Tuple[str, ...] = ()
+    compare_as_set: bool = False
+    missing_identity: MissingIdentityPolicy = MissingIdentityPolicy.FALLBACK
+    duplicates: DuplicateIdentityPolicy = DuplicateIdentityPolicy.ERROR
+    priority: int = 0
+    name: Optional[str] = None
+    _pattern_tokens: Tuple[PathToken, ...] = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        pattern_tokens = _parse_pattern(self.path)
+        match_by = _as_non_empty_string_tuple(self.match_by, "match_by")
+        sort_by = _as_non_empty_string_tuple(self.sort_by, "sort_by")
+        exclude_fields = _as_non_empty_string_tuple(self.exclude_fields, "exclude_fields")
+
+        if isinstance(self.normalizers, (str, bytes)) or not isinstance(
+            self.normalizers, Sequence
+        ):
+            raise CollectionStrategyError("normalizers must be a sequence of callables")
+        normalizers = tuple(self.normalizers)
+        if any(not callable(item) for item in normalizers):
+            raise CollectionStrategyError("all normalizers must be callable")
+        if self.filter_func is not None and not callable(self.filter_func):
+            raise CollectionStrategyError("filter_func must be callable")
+        if not isinstance(self.compare_as_set, bool):
+            raise CollectionStrategyError("compare_as_set must be a boolean")
+        if self.compare_as_set and match_by:
+            raise CollectionStrategyError("compare_as_set and match_by are mutually exclusive")
+        if self.compare_as_set and sort_by:
+            raise CollectionStrategyError("compare_as_set and sort_by are mutually exclusive")
+        if not isinstance(self.priority, int) or isinstance(self.priority, bool):
+            raise CollectionStrategyError("priority must be an integer")
+        if self.name is not None and (not isinstance(self.name, str) or not self.name):
+            raise CollectionStrategyError("name must be a non-empty string or None")
+
+        try:
+            missing_identity = MissingIdentityPolicy(self.missing_identity)
+        except (TypeError, ValueError) as exc:
+            raise CollectionStrategyError(
+                f"invalid missing_identity policy {self.missing_identity!r}"
+            ) from exc
+        try:
+            duplicates = DuplicateIdentityPolicy(self.duplicates)
+        except (TypeError, ValueError) as exc:
+            raise CollectionStrategyError(
+                f"invalid duplicates policy {self.duplicates!r}"
+            ) from exc
+
+        object.__setattr__(self, "match_by", match_by)
+        object.__setattr__(self, "sort_by", sort_by)
+        object.__setattr__(self, "exclude_fields", exclude_fields)
+        object.__setattr__(self, "normalizers", normalizers)
+        object.__setattr__(self, "missing_identity", missing_identity)
+        object.__setattr__(self, "duplicates", duplicates)
+        object.__setattr__(self, "_pattern_tokens", pattern_tokens)
+
+
+@dataclass
+class StrategyStats:
+    """Execution diagnostics for one concrete collection path on one input side."""
+
+    strategy: str
+    items: int = 0
+    filtered: int = 0
+    missing_identity: int = 0
+    duplicate_groups: int = 0
+
+
+@dataclass
+class _Context:
+    side: str
+    stats: Dict[str, StrategyStats] = field(default_factory=dict)
+
+
+@dataclass
+class _PreparedItem:
+    original_index: int
+    value: Any
+    identity: Optional[Tuple[Any, ...]] = None
+    sort_key: Optional[Tuple[SortKey, ...]] = None
+
+
+def _path_to_string(path: Tuple[Any, ...]) -> str:
+    result = "$"
+    for part in path:
+        if isinstance(part, int):
+            result += f"[{part}]"
+        elif isinstance(part, str) and part.isidentifier():
+            result += f".{part}"
+        else:
+            result += f"[{part!r}]"
+    return result
+
+
+def _pattern_matches(pattern: Tuple[PathToken, ...], path: Tuple[Any, ...]) -> bool:
+    if len(pattern) != len(path):
+        return False
+    for expected, actual in zip(pattern, path):
+        if expected is _ARRAY_WILDCARD:
+            if not isinstance(actual, int):
+                return False
+        elif expected is _KEY_WILDCARD:
+            if not isinstance(actual, str):
+                return False
+        elif expected != actual:
+            return False
+    return True
+
+
+def _extract(value: Any, relative_path: str, default: Any = _MISSING) -> Any:
+    """Extract a dotted relative path from mappings and integer-indexed lists."""
+    current = value
+    for token in relative_path.split("."):
+        if isinstance(current, Mapping):
+            if token not in current:
+                return default
+            current = current[token]
+        elif isinstance(current, Sequence) and not isinstance(
+            current, (str, bytes, bytearray)
+        ):
+            try:
+                current = current[int(token)]
+            except (ValueError, IndexError):
+                return default
+        else:
+            return default
+    return current
+
+
+def _scalar_component(
+    value: Any,
+    *,
+    field_name: Optional[str] = None,
+    location: Optional[str] = None,
+) -> Tuple[str, Any]:
+    if value is None:
+        return ("null", None)
+    if isinstance(value, bool):
+        return ("bool", value)
+    if isinstance(value, int):
+        return ("int", value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            detail = f"identity field {field_name!r} at {location}" if field_name else "value"
+            raise IdentityExtractionError(f"{detail} must be finite")
+        return ("float", value)
+    if isinstance(value, str):
+        return ("str", value)
+    detail = f"identity field {field_name!r} at {location}" if field_name else "value"
+    raise IdentityExtractionError(
+        f"{detail} must resolve to a JSON scalar; got {type(value).__name__}"
+    )
+
+
+def _identity_label(
+    identity: Tuple[Any, ...],
+    fields: Tuple[str, ...],
+    location: str,
+) -> str:
+    encoded = [
+        _scalar_component(value, field_name=field_name, location=location)
+        for field_name, value in zip(fields, identity)
+    ]
+    return json.dumps(encoded, ensure_ascii=False, separators=(",", ":"))
+
+
+def _stable_value(value: Any, *, location: str) -> SortKey:
+    """Return a total deterministic ordering key for JSON-compatible values."""
+    if value is _MISSING:
+        return (0,)
+    if value is None:
+        return (1,)
+    if isinstance(value, bool):
+        return (2, value)
+    if isinstance(value, int):
+        return (3, 0, value)
+    if isinstance(value, float):
+        if value == float("-inf"):
+            return (3, 1, 0)
+        if math.isfinite(value):
+            return (3, 1, 1, value)
+        if value == float("inf"):
+            return (3, 1, 2)
+        return (3, 1, 3)  # NaN
+    if isinstance(value, str):
+        return (4, value)
+    if isinstance(value, list):
+        return (5, tuple(_stable_value(item, location=location) for item in value))
+    if isinstance(value, Mapping):
+        if any(not isinstance(key, str) for key in value):
+            raise CollectionStrategyError(
+                f"sort key at {location} contains a mapping with non-string keys"
+            )
+        return (
+            6,
+            tuple(
+                (key, _stable_value(value[key], location=location))
+                for key in sorted(value)
+            ),
+        )
+    raise CollectionStrategyError(
+        f"sort key at {location} must be JSON-compatible; got {type(value).__name__}"
+    )
+
+
+class DeepJSONDiff(MappingABC[str, Any]):
+    """Compare JSON-like values with path-scoped collection semantics.
+
+    Path-sensitive DeepDiff options are rejected because matching strategies
+    change selected list paths into canonical identity-keyed mappings.
+    """
+
+    def __init__(
+        self,
+        t1: Any,
+        t2: Any,
+        *,
+        collection_strategies: Iterable[CollectionStrategy] = (),
+        **deepdiff_kwargs: Any,
+    ) -> None:
+        unsafe = sorted(_UNSAFE_DEEPDIFF_KWARGS.intersection(deepdiff_kwargs))
+        if unsafe:
+            raise CollectionStrategyError(
+                "path-sensitive DeepDiff options are not supported by DeepJSONDiff: "
+                + ", ".join(unsafe)
+            )
+
+        self.collection_strategies = tuple(collection_strategies)
+        self._validate_strategies()
+        self.stats: Dict[str, Dict[str, StrategyStats]] = {"left": {}, "right": {}}
+
+        left_context = _Context(side="left", stats=self.stats["left"])
+        right_context = _Context(side="right", stats=self.stats["right"])
+        self.canonical_t1 = self._canonicalize(t1, (), left_context)
+        self.canonical_t2 = self._canonicalize(t2, (), right_context)
+        self.diff = DeepDiff(self.canonical_t1, self.canonical_t2, **deepdiff_kwargs)
+
+    def _validate_strategies(self) -> None:
+        seen: Dict[Tuple[str, int], CollectionStrategy] = {}
+        for strategy in self.collection_strategies:
+            if not isinstance(strategy, CollectionStrategy):
+                raise CollectionStrategyError(
+                    "collection_strategies must contain CollectionStrategy instances"
+                )
+            key = (strategy.path, strategy.priority)
+            if key in seen:
+                raise CollectionStrategyError(
+                    f"ambiguous strategies for path {strategy.path!r} "
+                    f"at priority {strategy.priority}"
+                )
+            seen[key] = strategy
+
+    @staticmethod
+    def _specificity(strategy: CollectionStrategy) -> int:
+        return sum(
+            token is not _ARRAY_WILDCARD and token is not _KEY_WILDCARD
+            for token in strategy._pattern_tokens
+        )
+
+    def _resolve_strategy(self, path: Tuple[Any, ...]) -> Optional[CollectionStrategy]:
+        matches = [
+            strategy
+            for strategy in self.collection_strategies
+            if _pattern_matches(strategy._pattern_tokens, path)
+        ]
+        if not matches:
+            return None
+        matches.sort(
+            key=lambda item: (item.priority, self._specificity(item)),
+            reverse=True,
+        )
+        if len(matches) > 1:
+            first, second = matches[0], matches[1]
+            if (
+                first.priority == second.priority
+                and self._specificity(first) == self._specificity(second)
+            ):
+                raise CollectionStrategyError(
+                    "ambiguous collection strategies matched concrete path "
+                    f"{_path_to_string(path)!r}"
+                )
+        return matches[0]
+
+    def _canonicalize(self, value: Any, path: Tuple[Any, ...], context: _Context) -> Any:
+        strategy = self._resolve_strategy(path) if isinstance(value, list) else None
+        if isinstance(value, Mapping):
+            return {
+                key: self._canonicalize(item, path + (key,), context)
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return self._canonicalize_list(value, path, strategy, context)
+        return value
+
+    def _prepare_item(
+        self,
+        original: Any,
+        index: int,
+        path: Tuple[Any, ...],
+        strategy: CollectionStrategy,
+        context: _Context,
+        stat: StrategyStats,
+    ) -> Optional[_PreparedItem]:
+        item = deepcopy(original) if strategy.filter_func or strategy.normalizers else original
+        if strategy.filter_func is not None and not strategy.filter_func(item):
+            stat.filtered += 1
+            return None
+
+        for normalizer in strategy.normalizers:
+            item = normalizer(item)
+
+        identity: Optional[Tuple[Any, ...]] = None
+        if strategy.match_by:
+            identity = tuple(_extract(item, field) for field in strategy.match_by)
+
+        rendered = _path_to_string(path)
+        sort_key: Optional[Tuple[SortKey, ...]] = None
+        if strategy.sort_by:
+            sort_key = tuple(
+                _stable_value(
+                    _extract(item, field),
+                    location=f"{rendered} sort_by {field!r}",
+                )
+                for field in strategy.sort_by
+            )
+
+        if isinstance(item, Mapping) and strategy.exclude_fields:
+            item = dict(item)
+            for field_name in strategy.exclude_fields:
+                item.pop(field_name, None)
+
+        item = self._canonicalize(item, path + (index,), context)
+        return _PreparedItem(index, item, identity, sort_key)
+
+    def _canonicalize_list(
+        self,
+        values: List[Any],
+        path: Tuple[Any, ...],
+        strategy: Optional[CollectionStrategy],
+        context: _Context,
+    ) -> Any:
+        if strategy is None:
+            return [
+                self._canonicalize(item, path + (index,), context)
+                for index, item in enumerate(values)
+            ]
+
+        rendered = _path_to_string(path)
+        stat = StrategyStats(strategy=strategy.name or strategy.path, items=len(values))
+        context.stats[rendered] = stat
+
+        prepared = [
+            item
+            for index, original in enumerate(values)
+            if (item := self._prepare_item(original, index, path, strategy, context, stat))
+            is not None
+        ]
+
+        if strategy.match_by:
+            return self._index_by_identity(prepared, path, strategy, context, stat)
+
+        if strategy.sort_by:
+            prepared = sorted(prepared, key=lambda item: item.sort_key or ())
+        elif strategy.compare_as_set:
+            for item in prepared:
+                try:
+                    _scalar_component(item.value)
+                except IdentityExtractionError as exc:
+                    raise CollectionStrategyError(
+                        f"compare_as_set at {rendered} supports finite JSON scalar items only"
+                    ) from exc
+            prepared = sorted(
+                prepared,
+                key=lambda item: _stable_value(item.value, location=rendered),
+            )
+        return [item.value for item in prepared]
+
+    def _index_by_identity(
+        self,
+        prepared: List[_PreparedItem],
+        path: Tuple[Any, ...],
+        strategy: CollectionStrategy,
+        context: _Context,
+        stat: StrategyStats,
+    ) -> Dict[str, Any]:
+        rendered = _path_to_string(path)
+        grouped: Dict[str, List[_PreparedItem]] = {}
+        fallback: List[Any] = []
+
+        for prepared_item in prepared:
+            item_location = f"{rendered}[{prepared_item.original_index}]"
+            identity = prepared_item.identity
+            assert identity is not None
+
+            if any(value is _MISSING for value in identity):
+                stat.missing_identity += 1
+                if strategy.missing_identity is MissingIdentityPolicy.ERROR:
+                    missing = [
+                        field
+                        for field, value in zip(strategy.match_by, identity)
+                        if value is _MISSING
+                    ]
+                    raise IdentityExtractionError(
+                        f"missing identity field(s) {missing!r} on {context.side} input "
+                        f"at {item_location} while applying strategy {strategy.path!r}"
+                    )
+                if strategy.missing_identity is MissingIdentityPolicy.EXCLUDE:
+                    continue
+                fallback.append(prepared_item.value)
+                continue
+
+            label = _identity_label(identity, strategy.match_by, item_location)
+            grouped.setdefault(label, []).append(prepared_item)
+
+        result: Dict[str, Any] = {}
+        for label, group in grouped.items():
+            if len(group) > 1:
+                stat.duplicate_groups += 1
+                if strategy.duplicates is DuplicateIdentityPolicy.ERROR:
+                    raise DuplicateIdentityError(
+                        f"duplicate identity {label!r} on {context.side} input at "
+                        f"{rendered} while applying strategy {strategy.path!r}"
+                    )
+                if strategy.sort_by:
+                    group = sorted(group, key=lambda item: item.sort_key or ())
+                result[label] = [item.value for item in group]
+            else:
+                result[label] = group[0].value
+
+        if fallback:
+            result["__deepdiff_fallback__"] = fallback
+        return result
+
+    def get_stats(self) -> Dict[str, Dict[str, Dict[str, Any]]]:
+        """Return diagnostics separated by input side to avoid path conflation."""
+        return {
+            side: {
+                path: {
+                    "strategy": stat.strategy,
+                    "items": stat.items,
+                    "filtered": stat.filtered,
+                    "missing_identity": stat.missing_identity,
+                    "duplicate_groups": stat.duplicate_groups,
+                }
+                for path, stat in side_stats.items()
+            }
+            for side, side_stats in self.stats.items()
+        }
+
+    def __bool__(self) -> bool:
+        return bool(self.diff)
+
+    def __getitem__(self, key: str) -> Any:
+        return self.diff[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.diff)
+
+    def __len__(self) -> int:
+        return len(self.diff)
+
+    def __repr__(self) -> str:
+        return repr(self.diff)
+
+    def to_dict(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return self.diff.to_dict(*args, **kwargs)
+
+    def to_json(self, *args: Any, **kwargs: Any) -> str:
+        if kwargs.get("sort_keys") and "force_use_builtin_json" not in kwargs:
+            kwargs["force_use_builtin_json"] = True
+        return self.diff.to_json(*args, **kwargs)

--- a/docs/json_collection_strategies.rst
+++ b/docs/json_collection_strategies.rst
@@ -1,0 +1,163 @@
+JSON Collection Strategies
+==========================
+
+``DeepJSONDiff`` is an opt-in facade for comparing JSON-like values whose nested
+arrays require path-specific semantics. It builds canonical caller-isolated
+views and delegates the final recursive comparison to ``DeepDiff``. Existing
+``DeepDiff`` behaviour is unchanged.
+
+Basic identity matching
+-----------------------
+
+Use ``match_by`` when list records have a stable business identity::
+
+    from deepdiff import CollectionStrategy, DeepJSONDiff
+
+    diff = DeepJSONDiff(
+        expected,
+        actual,
+        collection_strategies=[
+            CollectionStrategy(
+                path="$.users",
+                match_by=("id",),
+            )
+        ],
+    )
+
+Reordering does not create differences. Additions, removals, and field changes
+remain visible against canonical identity-keyed paths.
+
+Selectors
+---------
+
+Selectors use a deliberately small JSONPath-like grammar:
+
+- ``$.users`` selects an object key.
+- ``$.groups[0].users`` selects one array index.
+- ``$.groups[*].users`` matches exactly one array index.
+- ``$.*.users`` matches exactly one object key.
+- ``$['a-b']`` selects a quoted key that cannot be written safely in dot form.
+
+Wildcards never cross additional levels. Diagnostic paths use the same quoted
+key syntax and can be reused as selectors. JSON object keys are expected to be
+strings.
+
+Relative identity and sort fields use dotted extraction and may include numeric
+list indexes, such as ``product.id`` or ``versions.0.number``.
+
+Identity values
+---------------
+
+Identity fields must resolve, after normalization, to finite JSON scalar values:
+``None``, booleans, integers, finite floats, or strings. Structured and
+non-finite values are rejected.
+
+Composite identities are encoded using a canonical type-preserving format, so
+values such as integer ``1``, float ``1.0``, and string ``"1"`` remain distinct
+and delimiter characters cannot cause collisions.
+
+Filtering, normalization, and exclusion
+---------------------------------------
+
+``filter_func`` and normalizers receive defensive copies and may mutate them
+without modifying caller-owned inputs. Copies are created only when callbacks
+are configured; otherwise canonicalization rebuilds the structure directly.
+
+Processing order is:
+
+1. Copy when callbacks require isolation.
+2. Apply ``filter_func``.
+3. Apply normalizers.
+4. Extract identity and sort fields.
+5. Remove ``exclude_fields``.
+6. Canonicalize nested content.
+
+Identity and sort fields may therefore also appear in ``exclude_fields``. They
+can control matching or ordering without remaining in the compared record.
+
+Sorting
+-------
+
+``sort_by`` creates a total, type-stable order for JSON-compatible values.
+Integers and floats are intentionally distinguished. Finite values, infinities,
+and NaN values have deterministic positions and do not produce mixed-type sort
+errors.
+
+Structured sort keys are supported only for JSON lists and mappings with string
+keys. Tuples, sets, mappings with non-string keys, and arbitrary objects are
+rejected rather than ordered through unstable ``repr`` output.
+
+Order-insensitive scalar arrays
+-------------------------------
+
+``compare_as_set=True`` performs multiset (bag) comparison:
+
+- order is ignored;
+- duplicate counts remain significant;
+- integer and float values remain type-distinct;
+- only finite JSON scalar values are accepted.
+
+It cannot be combined with ``match_by`` or ``sort_by``.
+
+Missing identities
+------------------
+
+The default ``MissingIdentityPolicy.FALLBACK`` retains records missing one or
+more identity fields and compares them in relative order. ``EXCLUDE`` omits
+them, and ``ERROR`` raises ``IdentityExtractionError``. Enum members and their
+string values are accepted.
+
+Duplicate identities
+--------------------
+
+Duplicate identities raise ``DuplicateIdentityError`` by default.
+``DuplicateIdentityPolicy.GROUP`` retains every record under the identity.
+Provide ``sort_by`` when duplicate-group order is not meaningful.
+
+Rule precedence
+---------------
+
+Higher ``priority`` wins when multiple strategies match. At equal priority, the
+pattern with more exact tokens wins. Equally specific matches are rejected as
+ambiguous.
+
+Diagnostics
+-----------
+
+``get_stats()`` separates diagnostics by input side::
+
+    stats = diff.get_stats()
+    left_users = stats["left"]["$.users"]
+    right_users = stats["right"]["$.users"]
+
+Each entry includes the selected strategy, input item count, filtered count,
+missing-identity count, and duplicate-group count. Keeping sides separate
+prevents statistics for different logical parents from being merged when a
+parent identity-matched collection is reordered.
+
+DeepDiff keyword compatibility
+------------------------------
+
+Identity matching changes selected arrays into canonical mappings. DeepDiff
+options that interpret caller-visible paths, object paths, or iterable positions
+would therefore operate on a different structure. ``DeepJSONDiff`` rejects
+these path-sensitive options instead of silently changing their meaning:
+
+- ``include_paths``
+- ``exclude_paths``
+- ``exclude_regex_paths``
+- ``ignore_order_func``
+- ``iterable_compare_func``
+- ``custom_operators``
+- ``exclude_obj_callback``
+- ``exclude_obj_callback_strict``
+
+Other keyword arguments are forwarded to the underlying ``DeepDiff`` instance.
+
+Result interface
+----------------
+
+``DeepJSONDiff`` is a composition-based facade, not a complete ``DeepDiff``
+subclass. It implements the read-only mapping interface and exposes ``diff`` for
+direct access to the underlying result. ``to_dict()`` and ``to_json()`` are
+delegated explicitly.

--- a/tests/test_json_diff.py
+++ b/tests/test_json_diff.py
@@ -1,0 +1,442 @@
+from copy import deepcopy
+
+import pytest
+
+from deepdiff import DeepDiff
+from deepdiff.json_diff import (
+    CollectionStrategy,
+    CollectionStrategyError,
+    DeepJSONDiff,
+    DuplicateIdentityError,
+    DuplicateIdentityPolicy,
+    IdentityExtractionError,
+    MissingIdentityPolicy,
+)
+
+
+def test_existing_deepdiff_behavior_is_unchanged():
+    result = DeepDiff([{"id": 1}, {"id": 2}], [{"id": 2}, {"id": 1}])
+    assert result
+    assert "values_changed" in result
+
+
+def test_identity_matching_ignores_reordering_and_reports_real_changes():
+    left = {"users": [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]}
+    right = {"users": [{"id": 2, "name": "B2"}, {"id": 3, "name": "C"}]}
+    result = DeepJSONDiff(
+        left,
+        right,
+        collection_strategies=[CollectionStrategy(path="$.users", match_by=("id",))],
+    )
+    assert set(result) == {
+        "dictionary_item_added",
+        "dictionary_item_removed",
+        "values_changed",
+    }
+
+
+def test_nested_wildcards_match_exactly_one_level():
+    left = {"accounts": [{"users": [{"id": 1}, {"id": 2}]}]}
+    right = {"accounts": [{"users": [{"id": 2}, {"id": 1}]}]}
+    assert not DeepJSONDiff(
+        left,
+        right,
+        collection_strategies=[
+            CollectionStrategy(path="$.accounts[*].users", match_by=("id",))
+        ],
+    )
+
+    deeper_left = {"accounts": [{"nested": [{"users": [{"id": 1}, {"id": 2}]}]}]}
+    deeper_right = {"accounts": [{"nested": [{"users": [{"id": 2}, {"id": 1}]}]}]}
+    assert DeepJSONDiff(
+        deeper_left,
+        deeper_right,
+        collection_strategies=[
+            CollectionStrategy(path="$.accounts[*].users", match_by=("id",))
+        ],
+    )
+
+
+def test_quoted_key_selector_is_round_trippable_with_stats_path():
+    result = DeepJSONDiff(
+        {"a-b": [{"id": 2}, {"id": 1}]},
+        {"a-b": [{"id": 1}, {"id": 2}]},
+        collection_strategies=[
+            CollectionStrategy(path="$['a-b']", match_by=("id",), name="hyphen")
+        ],
+    )
+    assert not result
+    assert result.get_stats()["left"]["$['a-b']"]["strategy"] == "hyphen"
+
+
+def test_root_and_numeric_index_patterns_are_supported():
+    assert not DeepJSONDiff(
+        [{"id": 2}, {"id": 1}],
+        [{"id": 1}, {"id": 2}],
+        collection_strategies=[CollectionStrategy(path="$", match_by=("id",))],
+    )
+    assert not DeepJSONDiff(
+        {"groups": [{"items": [{"id": 2}, {"id": 1}]}]},
+        {"groups": [{"items": [{"id": 1}, {"id": 2}]}]},
+        collection_strategies=[
+            CollectionStrategy(path="$.groups[0].items", match_by=("id",))
+        ],
+    )
+
+
+def test_composite_nested_identity_is_collision_safe():
+    left = {
+        "items": [
+            {"first": "a|str:b", "second": "", "value": 1},
+            {"first": "a", "second": "b", "value": 2},
+        ]
+    }
+    right = {"items": list(reversed(left["items"]))}
+    assert not DeepJSONDiff(
+        left,
+        right,
+        collection_strategies=[
+            CollectionStrategy(path="$.items", match_by=("first", "second"))
+        ],
+    )
+
+
+@pytest.mark.parametrize("identity", [None, False, True, 1, 1.5, "1"])
+def test_identity_scalar_types_are_supported(identity):
+    result = DeepJSONDiff(
+        {"items": [{"id": identity}]},
+        {"items": [{"id": identity}]},
+        collection_strategies=[CollectionStrategy(path="$.items", match_by=("id",))],
+    )
+    assert not result
+
+
+@pytest.mark.parametrize("identity", [{"nested": 1}, [1], float("nan"), float("inf")])
+def test_invalid_identity_values_are_rejected(identity):
+    with pytest.raises(IdentityExtractionError):
+        DeepJSONDiff(
+            {"items": [{"id": identity}]},
+            {"items": []},
+            collection_strategies=[
+                CollectionStrategy(path="$.items", match_by=("id",))
+            ],
+        )
+
+
+def test_identity_is_extracted_before_excluded_fields_are_removed():
+    left = {"items": [{"id": 1, "value": "same"}]}
+    right = {"items": [{"id": 1, "value": "same"}]}
+    result = DeepJSONDiff(
+        left,
+        right,
+        collection_strategies=[
+            CollectionStrategy(
+                path="$.items",
+                match_by=("id",),
+                exclude_fields=("id",),
+            )
+        ],
+    )
+    assert not result
+    assert "__deepdiff_fallback__" not in result.canonical_t1["items"]
+
+
+def test_mutating_filter_and_normalizer_do_not_mutate_inputs():
+    left = {"items": [{"id": 1, "active": True, "region": "IN"}]}
+    right = {"items": [{"id": 1, "active": True, "region": "in"}]}
+    original_left = deepcopy(left)
+    original_right = deepcopy(right)
+
+    def filter_func(item):
+        item["filter_seen"] = True
+        return item["active"]
+
+    def normalize(item):
+        item["region"] = item["region"].lower()
+        item.pop("filter_seen", None)
+        return item
+
+    result = DeepJSONDiff(
+        left,
+        right,
+        collection_strategies=[
+            CollectionStrategy(
+                path="$.items",
+                match_by=("id",),
+                filter_func=filter_func,
+                normalizers=(normalize,),
+            )
+        ],
+    )
+    assert not result
+    assert left == original_left
+    assert right == original_right
+
+
+def test_sort_by_handles_finite_and_non_finite_numbers_without_type_errors():
+    values = [
+        {"rank": float("inf")},
+        {"rank": 1},
+        {"rank": float("-inf")},
+        {"rank": float("nan")},
+        {"rank": 1.5},
+    ]
+    result = DeepJSONDiff(
+        {"items": values},
+        {"items": list(reversed(values))},
+        collection_strategies=[CollectionStrategy(path="$.items", sort_by=("rank",))],
+    )
+    assert not result
+
+
+def test_sort_by_is_type_stable_for_int_and_float():
+    result = DeepJSONDiff(
+        {"items": [{"rank": 1.0}, {"rank": 1}]},
+        {"items": [{"rank": 1}, {"rank": 1.0}]},
+        collection_strategies=[CollectionStrategy(path="$.items", sort_by=("rank",))],
+    )
+    assert not result
+    assert isinstance(result.canonical_t1["items"][0]["rank"], int)
+    assert isinstance(result.canonical_t1["items"][1]["rank"], float)
+
+
+def test_sort_by_supports_json_lists_and_string_keyed_mappings():
+    left = {
+        "items": [
+            {"rank": {"b": 2, "a": 1}},
+            {"rank": [2, 1]},
+            {"rank": [1, 2]},
+        ]
+    }
+    right = {"items": list(reversed(left["items"]))}
+    assert not DeepJSONDiff(
+        left,
+        right,
+        collection_strategies=[CollectionStrategy(path="$.items", sort_by=("rank",))],
+    )
+
+
+@pytest.mark.parametrize("value", [{1: "bad"}, (1, 2), {1, 2}, object()])
+def test_sort_by_rejects_non_json_sort_keys(value):
+    with pytest.raises(CollectionStrategyError, match="sort key"):
+        DeepJSONDiff(
+            {"items": [{"rank": value}]},
+            {"items": [{"rank": value}]},
+            collection_strategies=[
+                CollectionStrategy(path="$.items", sort_by=("rank",))
+            ],
+        )
+
+
+def test_compare_as_set_is_type_stable_and_preserves_duplicates():
+    result = DeepJSONDiff(
+        {"items": [1, 1.0, 1]},
+        {"items": [1.0, 1, 1]},
+        collection_strategies=[
+            CollectionStrategy(path="$.items", compare_as_set=True)
+        ],
+    )
+    assert not result
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"id": 1},
+        [1],
+        (1,),
+        {1},
+        frozenset({1}),
+        b"x",
+        bytearray(b"x"),
+        object(),
+        float("nan"),
+        float("inf"),
+    ],
+)
+def test_compare_as_set_accepts_only_finite_json_scalars(value):
+    with pytest.raises(CollectionStrategyError, match="finite JSON scalar"):
+        DeepJSONDiff(
+            {"items": [value]},
+            {"items": [value]},
+            collection_strategies=[
+                CollectionStrategy(path="$.items", compare_as_set=True)
+            ],
+        )
+
+
+def test_missing_identity_policies_and_side_separated_stats():
+    result = DeepJSONDiff(
+        {"items": [{"id": 1}, {"name": "left"}]},
+        {"items": [{"name": "right"}, {"id": 1}]},
+        collection_strategies=[
+            CollectionStrategy(path="$.items", match_by=("id",))
+        ],
+    )
+    stats = result.get_stats()
+    assert stats["left"]["$.items"]["missing_identity"] == 1
+    assert stats["right"]["$.items"]["missing_identity"] == 1
+
+    with pytest.raises(IdentityExtractionError, match="right input"):
+        DeepJSONDiff(
+            {"items": []},
+            {"items": [{"name": "right"}]},
+            collection_strategies=[
+                CollectionStrategy(
+                    path="$.items",
+                    match_by=("id",),
+                    missing_identity=MissingIdentityPolicy.ERROR,
+                )
+            ],
+        )
+
+    excluded = DeepJSONDiff(
+        {"items": [{"id": 1}, {"name": "left"}]},
+        {"items": [{"id": 1}, {"name": "right"}]},
+        collection_strategies=[
+            CollectionStrategy(
+                path="$.items",
+                match_by=("id",),
+                missing_identity="exclude",
+            )
+        ],
+    )
+    assert not excluded
+
+
+def test_duplicate_identity_policies_and_stats():
+    with pytest.raises(DuplicateIdentityError, match="left input"):
+        DeepJSONDiff(
+            {"items": [{"id": 1}, {"id": 1}]},
+            {"items": []},
+            collection_strategies=[
+                CollectionStrategy(path="$.items", match_by=("id",))
+            ],
+        )
+
+    result = DeepJSONDiff(
+        {"items": [{"id": 1, "v": 2}, {"id": 1, "v": 1}]},
+        {"items": [{"id": 1, "v": 1}, {"id": 1, "v": 2}]},
+        collection_strategies=[
+            CollectionStrategy(
+                path="$.items",
+                match_by=("id",),
+                sort_by=("v",),
+                duplicates=DuplicateIdentityPolicy.GROUP,
+            )
+        ],
+    )
+    assert not result
+    assert result.get_stats()["left"]["$.items"]["duplicate_groups"] == 1
+
+
+def test_nested_stats_do_not_merge_different_logical_parents_across_sides():
+    left = {
+        "orders": [
+            {"id": "A", "items": [{"sku": 1}, {"sku": 2}]},
+            {"id": "B", "items": [{"sku": 3}]},
+        ]
+    }
+    right = {"orders": list(reversed(left["orders"]))}
+    result = DeepJSONDiff(
+        left,
+        right,
+        collection_strategies=[
+            CollectionStrategy(path="$.orders", match_by=("id",)),
+            CollectionStrategy(path="$.orders[*].items", match_by=("sku",)),
+        ],
+    )
+    assert not result
+    stats = result.get_stats()
+    assert stats["left"]["$.orders[0].items"]["items"] == 2
+    assert stats["right"]["$.orders[0].items"]["items"] == 1
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        "include_paths",
+        "exclude_paths",
+        "exclude_regex_paths",
+        "ignore_order_func",
+        "iterable_compare_func",
+        "custom_operators",
+    ],
+)
+def test_path_sensitive_deepdiff_options_are_rejected(option):
+    with pytest.raises(CollectionStrategyError, match="path-sensitive"):
+        DeepJSONDiff({}, {}, **{option: object()})
+
+
+def test_unrelated_deepdiff_kwargs_are_forwarded():
+    result = DeepJSONDiff({"value": 1}, {"value": 1.0}, ignore_numeric_type_changes=True)
+    assert not result
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"path": "users"},
+        {"path": "$."},
+        {"path": "$.users["},
+        {"path": "$.users[-1]"},
+        {"path": "$.users[abc]"},
+        {"path": "$['unterminated]"},
+        {"path": "$.users", "match_by": "id"},
+        {"path": "$.users", "sort_by": ("",)},
+        {"path": "$.users", "exclude_fields": ("",)},
+        {"path": "$.users", "normalizers": "normalize"},
+        {"path": "$.users", "normalizers": (None,)},
+        {"path": "$.users", "filter_func": "filter"},
+        {"path": "$.users", "priority": True},
+        {"path": "$.users", "name": ""},
+        {"path": "$.users", "missing_identity": "unknown"},
+        {"path": "$.users", "duplicates": "unknown"},
+        {"path": "$.users", "compare_as_set": True, "sort_by": ("id",)},
+        {"path": "$.users", "compare_as_set": True, "match_by": ("id",)},
+    ],
+)
+def test_invalid_configuration_is_rejected(kwargs):
+    with pytest.raises(CollectionStrategyError):
+        CollectionStrategy(**kwargs)
+
+
+def test_strategy_resolution_precedence_and_ambiguity():
+    result = DeepJSONDiff(
+        {"a": {"users": [{"id": 2}, {"id": 1}]}},
+        {"a": {"users": [{"id": 1}, {"id": 2}]}},
+        collection_strategies=[
+            CollectionStrategy(path="$.*.users", sort_by=("id",), priority=1),
+            CollectionStrategy(path="$.a.users", priority=0),
+        ],
+    )
+    assert not result
+
+    with pytest.raises(CollectionStrategyError, match="ambiguous collection strategies"):
+        DeepJSONDiff(
+            {"a": {"users": []}},
+            {"a": {"users": []}},
+            collection_strategies=[
+                CollectionStrategy(path="$.*.users"),
+                CollectionStrategy(path="$.a.*"),
+            ],
+        )
+
+
+def test_duplicate_strategy_and_non_strategy_entries_are_rejected():
+    strategy = CollectionStrategy(path="$.users")
+    with pytest.raises(CollectionStrategyError):
+        DeepJSONDiff({}, {}, collection_strategies=[strategy, strategy])
+    with pytest.raises(CollectionStrategyError):
+        DeepJSONDiff({}, {}, collection_strategies=[object()])
+
+
+def test_mapping_facade_and_serialization_delegation():
+    result = DeepJSONDiff({"value": 1}, {"value": 2})
+    assert list(result.keys()) == ["values_changed"]
+    assert list(result.items())
+    assert result.get("values_changed") is not None
+    assert len(result) == 1
+    assert "values_changed" in repr(result)
+    assert result.to_dict() == result.diff.to_dict()
+    assert result.to_json(sort_keys=True)

--- a/tests/test_json_diff_merge_contracts.py
+++ b/tests/test_json_diff_merge_contracts.py
@@ -1,0 +1,69 @@
+import pytest
+
+from deepdiff.json_diff import (
+    CollectionStrategy,
+    CollectionStrategyError,
+    DeepJSONDiff,
+    DuplicateIdentityPolicy,
+)
+
+
+def test_sort_by_is_extracted_before_excluded_fields_are_removed():
+    left = {
+        "items": [
+            {"id": "late", "rank": 2},
+            {"id": "early", "rank": 1},
+        ]
+    }
+    right = {
+        "items": [
+            {"id": "early", "rank": 1},
+            {"id": "late", "rank": 2},
+        ]
+    }
+
+    result = DeepJSONDiff(
+        left,
+        right,
+        collection_strategies=[
+            CollectionStrategy(
+                path="$.items",
+                sort_by=("rank",),
+                exclude_fields=("rank",),
+            )
+        ],
+    )
+
+    assert not result
+    assert all("rank" not in item for item in result.canonical_t1["items"])
+    assert all("rank" not in item for item in result.canonical_t2["items"])
+
+
+def test_duplicate_group_sort_key_is_extracted_before_exclusion():
+    strategy = CollectionStrategy(
+        path="$.items",
+        match_by=("id",),
+        sort_by=("version",),
+        exclude_fields=("version",),
+        duplicates=DuplicateIdentityPolicy.GROUP,
+    )
+    left = {
+        "items": [
+            {"id": 1, "version": 2, "value": "new"},
+            {"id": 1, "version": 1, "value": "old"},
+        ]
+    }
+    right = {"items": list(reversed(left["items"]))}
+
+    result = DeepJSONDiff(left, right, collection_strategies=[strategy])
+
+    assert not result
+
+
+@pytest.mark.parametrize(
+    "option",
+    ["exclude_obj_callback", "exclude_obj_callback_strict"],
+)
+def test_path_sensitive_object_callbacks_are_rejected(option):
+    with pytest.raises(CollectionStrategyError, match="path-sensitive"):
+        DeepJSONDiff({}, {}, **{option: lambda *_args: False})


### PR DESCRIPTION
## Problem statement

DeepDiff compares arbitrary Python and JSON-like structures, but nested API collections are often unordered and keyed by business identity rather than list position. Positional comparison can create cascading false positives when records are inserted, removed, or reordered.

This PR adds an opt-in, reusable normalization layer for declaring collection-specific semantics without changing existing `DeepDiff` behavior.

## Proposed solution

The PR introduces `DeepJSONDiff` and `CollectionStrategy`. Both inputs are converted into canonical caller-isolated views, then compared by the existing `DeepDiff` engine.

```python
from deepdiff import CollectionStrategy, DeepJSONDiff

result = DeepJSONDiff(
    expected,
    actual,
    collection_strategies=[
        CollectionStrategy(
            path="$.orders[*].items",
            match_by=("product.id", "warehouse.code"),
            filter_func=lambda item: item.get("active", True),
            exclude_fields=("generatedAt", "requestId"),
        )
    ],
)
```

The existing `DeepDiff` constructor and comparison semantics remain unchanged.

## Selector semantics

Supported selectors include:

```text
$.users
$.groups[0].users
$.groups[*].users
$.*.users
$['a-b']
```

- `[*]` matches exactly one array index.
- `.*` matches exactly one object key.
- Quoted bracket selectors address keys that cannot be represented safely in dot form.
- Wildcards do not cross path levels.
- Higher `priority` wins.
- At equal priority, the pattern with more exact tokens wins.
- Equally specific matches are rejected as ambiguous.

JSON object keys are expected to be strings. Diagnostic paths use the same quoted-key syntax and can be reused as selectors.

## Collection behavior

### Identity matching

`match_by` supports single, composite, and nested fields. Identity values must resolve after normalization to finite JSON scalars: `None`, booleans, integers, finite floats, or strings.

Identity labels use canonical type-preserving encoding, so integer `1`, float `1.0`, and string `"1"` remain distinct and composite identities cannot collide through delimiter characters.

### Filtering, normalization, sorting, and exclusion

Filters and normalizers receive defensive copies and may mutate them without modifying caller-owned payloads. Copies are created only when callbacks are configured.

Processing order is:

1. apply the filter;
2. apply normalizers;
3. capture identity and sort fields;
4. remove excluded fields;
5. canonicalize nested content.

Identity and sort fields may therefore be excluded from the compared record while still controlling matching or ordering.

`sort_by` provides a total, type-stable order for JSON-compatible values. Integers and floats remain distinct. Finite values, infinities, and NaN values have deterministic positions without heterogeneous comparison failures.

Structured sort keys are restricted to JSON lists and mappings with string keys. Unsupported values are rejected instead of being ordered through unstable `repr()` output.

### Order-insensitive scalar arrays

`compare_as_set=True` performs multiset/bag comparison:

- order is ignored;
- duplicate counts remain significant;
- integer and float values remain type-distinct;
- only finite JSON scalar values are accepted;
- it cannot be combined with `match_by` or `sort_by`.

### Missing and duplicate identities

Missing identity policies:

- `fallback`: retain records in an ordered fallback collection;
- `exclude`: omit them;
- `error`: raise `IdentityExtractionError` with input side and path context.

Duplicate policies:

- `error`: raise `DuplicateIdentityError`;
- `group`: retain every record under the identity and optionally order the group with `sort_by`.

Enum members and string values are accepted.

### Diagnostics

`get_stats()` separates diagnostics by input side:

```python
stats["left"]["$.orders[0].items"]
stats["right"]["$.orders[0].items"]
```

Each entry reports the selected strategy, input item count, filtered count, missing-identity count, and duplicate-group count. Separating sides prevents unrelated parent records from being conflated after parent reordering.

## DeepDiff keyword compatibility

Identity matching changes selected arrays into canonical mappings. Options whose behavior depends on caller-visible paths, object paths, or iterable positions are rejected instead of being interpreted against a different structure:

- `include_paths`
- `exclude_paths`
- `exclude_regex_paths`
- `ignore_order_func`
- `iterable_compare_func`
- `custom_operators`
- `exclude_obj_callback`
- `exclude_obj_callback_strict`

Other keyword arguments are forwarded to the underlying `DeepDiff` instance.

## Result interface

`DeepJSONDiff` is a composition-based facade rather than a complete `DeepDiff` subclass. It implements the read-only `Mapping` interface, delegates `to_dict()` and `to_json()`, and exposes the underlying result through `result.diff`.

## Backward compatibility

The feature is fully opt-in:

- existing `DeepDiff` behavior is unchanged;
- no strategy is applied unless the caller constructs `DeepJSONDiff`;
- caller-owned inputs are not mutated;
- existing views, Delta behavior, serialization, and multiprocessing paths remain untouched.

## Files changed

- `deepdiff/json_diff.py` — facade, strategy model, selector parsing, canonicalization, identity matching, sorting, policies, diagnostics, and compatibility boundaries.
- `deepdiff/__init__.py` — public exports.
- `tests/test_json_diff.py` — primary functional, regression, and edge-case coverage.
- `tests/test_json_diff_merge_contracts.py` — final sorting/exclusion and callback-compatibility contract tests.
- `docs/json_collection_strategies.rst` — public behavior and API documentation.
- `deepdiff/docstrings/index.rst` — documentation navigation and unreleased note.

No custom GitHub Actions workflow is included.

## Validation performed

The implementation is validated across Python 3.10–3.14 and includes focused tests for:

- reordered nested collections;
- additions, removals, and modifications together;
- exact one-level wildcards and quoted-key selectors;
- collision-safe composite identities;
- scalar identity enforcement;
- identity and sort extraction before exclusion;
- callback isolation;
- finite and non-finite numeric sorting;
- type-stable integer/float multiset comparison;
- structured JSON sorting;
- duplicate-group ordering before exclusion;
- side-separated nested diagnostics;
- missing and duplicate policies on both inputs;
- invalid strategy rejection;
- complete path-sensitive DeepDiff option rejection;
- deterministic serialization and mapping behavior.

## Scope and limitations

This PR provides deterministic exact reconciliation. It does not infer business identity or perform fuzzy matching. The selector grammar is intentionally smaller than full JSONPath. Relative identity and sort fields use dotted extraction and numeric list indexes.

For identity-matched collections, result paths contain canonical identity keys rather than unstable original list indexes.