### PR TITLE
Fix Delta JSON round-trip crash when orjson is not installed

### DIFF
--- a/deepdiff/delta.py
+++ b/deepdiff/delta.py
@@ -99,11 +99,14 @@ class Delta:
                     for path, op_codes in result['_iterable_opcodes'].items():
                         _iterable_opcodes[path] = []
                         for op_code in op_codes:
-                            _iterable_opcodes[path].append(
-                                Opcode(
-                                    **op_code
-                                )
-                            )
+                            # Serializers differ in how they encode the Opcode
+                            # NamedTuple: orjson uses JSON_CONVERTOR and emits a
+                            # mapping, but stdlib json (the fallback when orjson
+                            # is not installed) encodes it as a positional array.
+                            if isinstance(op_code, Mapping):
+                                _iterable_opcodes[path].append(Opcode(**op_code))
+                            else:
+                                _iterable_opcodes[path].append(Opcode(*op_code))
                     result['_iterable_opcodes'] = _iterable_opcodes
                 return result
 

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -2820,6 +2820,26 @@ class TestDeltaCompareFunc:
         assert l2 == l1 + delta5
         assert l1 == l2 - delta5
 
+    def test_delta_iterable_opcodes_json_roundtrip_builtin_json(self):
+        # A list diff that goes through difflib opcodes (reorder / duplicates)
+        # serializes each Opcode NamedTuple. orjson emits it as a mapping, but
+        # the stdlib json fallback (used when orjson is not installed) emits it
+        # as a positional array; the deserializer must accept both. Forcing the
+        # builtin json path exercises the array shape even where orjson is
+        # installed, so a plain-install regression cannot hide behind orjson.
+        t1 = ['a', 'b', 'c', 'd', 'b', 'e']
+        t2 = ['b', 'c', 'x', 'b', 'e', 'f']
+        diff = DeepDiff(t1, t2)
+
+        def builtin_json_dumps(item):
+            return json_dumps(item, force_use_builtin_json=True)
+
+        dump = Delta(diff, bidirectional=True, serializer=builtin_json_dumps).dumps()
+        delta = Delta(dump, bidirectional=True, deserializer=json_loads)
+
+        assert t1 + delta == t2
+        assert t2 - delta == t1
+
     def test_delta_flat_rows(self):
         t1 = {"key1": "value1"}
         t2 = {"field2": {"key2": "value2"}}


### PR DESCRIPTION
### The bug

`Delta`'s documented JSON round-trip crashes on a default install (one without the optional `orjson` extra) for any list diff that goes through difflib opcodes — i.e. reorders or duplicates:

```python
from deepdiff import DeepDiff, Delta
from deepdiff.serialization import json_dumps, json_loads

t1 = ['a', 'b', 'c', 'd', 'b', 'e']
t2 = ['b', 'c', 'x', 'b', 'e', 'f']
diff = DeepDiff(t1, t2)

dump = Delta(diff, serializer=json_dumps).dumps()
Delta(dump, deserializer=json_loads)      # TypeError
# deepdiff.helper.Opcode() argument after ** must be a mapping, not list
```

This is the repo's own contract: `tests/test_delta.py::TestDeltaCompareFunc::test_list_of_alphabet_and_its_delta` already asserts exactly this round-trip. It passes in CI only because the dev/test environment installs `orjson`. On a plain `pip install deepdiff` that test fails, because `orjson` is optional (`[project.dependencies]` is just `orderly-set`; `orjson` lives in the `optimize`/`dev`/`test` extras).

### Root cause

A serialize/deserialize asymmetry around the `Opcode` NamedTuple:

- **Serialize** — with `orjson`, the encoder's `default` callback runs `JSON_CONVERTOR[tuple]` (`serialization.py`), turning each `Opcode` into a **mapping** via `_asdict()`. The stdlib `json` fallback (`serialization.py`, `json_dumps` when `orjson` is `None`) serializes any `tuple`/NamedTuple subclass **natively as a JSON array** and never invokes `default`, so an `Opcode` becomes a positional list like `["equal", 1, 3, 0, 2, null, null]`.
- **Deserialize** — `delta.py` unconditionally does `Opcode(**op_code)`, assuming a mapping. On an `orjson`-less install the opcode is a list, so `**list` raises `TypeError`.

A serialize-side fix alone can't work: stdlib `json` never calls `default` for tuple subclasses, so the robust fix is on deserialization.

### The fix

Accept both encodings when rebuilding opcodes — mapping → `Opcode(**op_code)`, array → `Opcode(*op_code)` (the array is in NamedTuple field order, so positional reconstruction is exact).

### Verification (re-runnable from the diff)

- Without `orjson`, before the fix: `test_list_of_alphabet_and_its_delta` fails at `delta.py` with the `TypeError` above. After the fix it passes, and the full `tests/test_delta.py` goes from 25 failures to 1.
- With `orjson` (the CI condition): `tests/test_delta.py` is **129 passed, 0 failed** — the mapping path is untouched, so no regression.
- Added `test_delta_iterable_opcodes_json_roundtrip_builtin_json`, which forces the stdlib-json path via `force_use_builtin_json=True`. It fails on the current code **even with `orjson` installed**, so the round-trip is now guarded regardless of the install, not just when `orjson` happens to be absent.

### One thing left out of scope

The remaining no-`orjson` failure is `test_delta_repr`: it asserts `orjson`'s compact separators (`{"iterable_item_added":{...}}`), while stdlib `json` emits spaces (`{"iterable_item_added": {...}}`). That's a separate repr/formatting assumption, unrelated to this crash — I left it alone to keep the diff focused, but happy to address it here or in a follow-up if you'd prefer.

Base branch is `dev` per `AGENTS.md`.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the tests, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
